### PR TITLE
修复同时使用多个函数时crash的问题

### DIFF
--- a/GaiaXAnalyze/GXAnalyzeCore/GXAnalyze.cpp
+++ b/GaiaXAnalyze/GXAnalyzeCore/GXAnalyze.cpp
@@ -1143,6 +1143,7 @@ long GXAnalyze::check(string s, vector<GXATSNode> array, void *p_analyze, void *
                                         }
                                         --valueSize;
                                         isFunction = false;
+                                        paramsSize = 0;
                                         if (fun->tag == GX_TAG_STRING && fun->str != NULL) {
                                             delete[] fun->str;
                                             fun->str = NULL;

--- a/GaiaXiOS/GaiaXiOS/Binding/Expression/GXAnalyzeCore/GXAnalyze.cpp
+++ b/GaiaXiOS/GaiaXiOS/Binding/Expression/GXAnalyzeCore/GXAnalyze.cpp
@@ -1143,6 +1143,7 @@ long GXAnalyze::check(string s, vector<GXATSNode> array, void *p_analyze, void *
                                         }
                                         --valueSize;
                                         isFunction = false;
+                                        paramsSize = 0;
                                         if (fun->tag == GX_TAG_STRING && fun->str != NULL) {
                                             delete[] fun->str;
                                             fun->str = NULL;


### PR DESCRIPTION
参数数组下标没有置0导致内存下标使用越界发生crash，已修复