### PR TITLE
Gaiax Lottie动画 Android对齐Ios实现

### DIFF
--- a/GaiaXAdapterAndroid/src/main/java/com/alibaba/gaiax/adapter/GXAdapter.kt
+++ b/GaiaXAdapterAndroid/src/main/java/com/alibaba/gaiax/adapter/GXAdapter.kt
@@ -32,6 +32,9 @@ class GXAdapter : GXTemplateEngine.GXIAdapter {
             .registerExtensionViewSupport(
                 GXViewKey.VIEW_TYPE_IMAGE,
                 GXAdapterImageView::class.java
+            ).registerExtensionViewSupport(
+                GXViewKey.VIEW_TYPE_LOTTIE,
+                GXAdapterLottieCreate::localCreateLottieView
             )
     }
 }

--- a/GaiaXAdapterAndroid/src/main/java/com/alibaba/gaiax/adapter/GXAdapterLottieAnimation.kt
+++ b/GaiaXAdapterAndroid/src/main/java/com/alibaba/gaiax/adapter/GXAdapterLottieAnimation.kt
@@ -17,10 +17,6 @@
 package com.alibaba.gaiax.adapter
 
 import android.animation.Animator
-import android.content.Context
-import android.view.LayoutInflater
-import android.view.ViewGroup
-import android.widget.AbsoluteLayout
 import com.airbnb.lottie.LottieAnimationView
 import com.airbnb.lottie.LottieComposition
 import com.airbnb.lottie.LottieCompositionFactory
@@ -35,7 +31,7 @@ import com.alibaba.gaiax.template.animation.GXLottieAnimation
 import com.alibaba.gaiax.template.factory.GXExpressionFactory
 import com.alibaba.gaiax.utils.setValueExt
 
-class GXAdapterLottieAnimation : GXLottieAnimation() {
+internal class GXAdapterLottieAnimation : GXLottieAnimation() {
 
     override fun executeAnimation(
         gxState: GXIExpression?,
@@ -44,13 +40,11 @@ class GXAdapterLottieAnimation : GXLottieAnimation() {
         gxNode: GXNode,
         gxTemplateData: JSONObject
     ) {
-        val lottieContainer = (gxNode.view as? ViewGroup) ?: return
         val gxAnimationData = gxAnimationExpression?.value(gxTemplateData) as? JSONObject
 
         val remoteUri = this.gxRemoteUri?.value(gxTemplateData) as? String
         if (remoteUri != null) {
             remotePlay(
-                lottieContainer,
                 gxTemplateContext,
                 gxNode,
                 gxTemplateData,
@@ -65,7 +59,6 @@ class GXAdapterLottieAnimation : GXLottieAnimation() {
         val localUri = this.gxLocalUri?.value(gxTemplateData) as? String
         if (localUri != null) {
             localPlay(
-                lottieContainer,
                 gxTemplateContext,
                 gxNode,
                 gxTemplateData,
@@ -85,18 +78,6 @@ class GXAdapterLottieAnimation : GXLottieAnimation() {
         return value
     }
 
-    private fun localCreateLottieView(context: Context): LottieAnimationView {
-        val lottieView: LottieAnimationView = LayoutInflater.from(context)
-            .inflate(R.layout.gaiax_inner_lottie_auto_play, null) as LottieAnimationView
-        lottieView.layoutParams = AbsoluteLayout.LayoutParams(
-            AbsoluteLayout.LayoutParams.MATCH_PARENT,
-            AbsoluteLayout.LayoutParams.MATCH_PARENT,
-            0,
-            0
-        )
-        return lottieView
-    }
-
     private fun localInitLottieLocalResourceDir(value: String, lottieView: LottieAnimationView) {
         val dirIndex = value.indexOf("/")
         if (dirIndex > 0) {
@@ -108,7 +89,6 @@ class GXAdapterLottieAnimation : GXLottieAnimation() {
     }
 
     private fun localPlay(
-        lottieContainer: ViewGroup,
         gxTemplateContext: GXTemplateContext,
         gxNode: GXNode,
         gxTemplateData: JSONObject,
@@ -117,12 +97,7 @@ class GXAdapterLottieAnimation : GXLottieAnimation() {
         localUri: String,
         loopCount: Int
     ) {
-        val lottieView: LottieAnimationView? = if (lottieContainer.childCount == 0) {
-            localCreateLottieView(lottieContainer.context)
-        } else {
-            lottieContainer.getChildAt(0) as? LottieAnimationView
-        }
-
+        val lottieView: LottieAnimationView? = gxNode.lottieView as? LottieAnimationView
         if (lottieView?.isAnimating == true || gxNode.isAnimating) {
             return
         }
@@ -170,28 +145,11 @@ class GXAdapterLottieAnimation : GXLottieAnimation() {
             }
 
         })
+        lottieView.isClickable = false
         lottieView.playAnimation()
-
-        if (lottieContainer.childCount == 0) {
-            lottieView.isClickable = false
-            lottieContainer.addView(lottieView)
-        }
-    }
-
-    private fun remoteCreateLottieView(context: Context): LottieAnimationView {
-        val lottieView: LottieAnimationView = LayoutInflater.from(context)
-            .inflate(R.layout.gaiax_inner_lottie_auto_play, null) as LottieAnimationView
-        lottieView.layoutParams = AbsoluteLayout.LayoutParams(
-            AbsoluteLayout.LayoutParams.MATCH_PARENT,
-            AbsoluteLayout.LayoutParams.MATCH_PARENT,
-            0,
-            0
-        )
-        return lottieView
     }
 
     private fun remotePlay(
-        lottieContainer: ViewGroup,
         gxTemplateContext: GXTemplateContext,
         gxNode: GXNode,
         gxTemplateData: JSONObject,
@@ -200,11 +158,7 @@ class GXAdapterLottieAnimation : GXLottieAnimation() {
         remoteUri: String,
         loopCount: Int
     ) {
-        val lottieView: LottieAnimationView? = if (lottieContainer.childCount == 0) {
-            remoteCreateLottieView(lottieContainer.context)
-        } else {
-            lottieContainer.getChildAt(0) as? LottieAnimationView
-        }
+        val lottieView: LottieAnimationView? = gxNode.lottieView as? LottieAnimationView
 
         if (lottieView?.isAnimating == true || gxNode.isAnimating) {
             return
@@ -261,14 +215,10 @@ class GXAdapterLottieAnimation : GXLottieAnimation() {
                                 })
                         }
                     })
+                    lottieView.isClickable = false
                     lottieView.playAnimation()
                 }
             }
         })
-
-        if (lottieContainer.childCount == 0) {
-            lottieView.isClickable = false
-            lottieContainer.addView(lottieView)
-        }
     }
 }

--- a/GaiaXAdapterAndroid/src/main/java/com/alibaba/gaiax/adapter/GXAdapterLottieCreate.kt
+++ b/GaiaXAdapterAndroid/src/main/java/com/alibaba/gaiax/adapter/GXAdapterLottieCreate.kt
@@ -1,0 +1,22 @@
+package com.alibaba.gaiax.adapter
+
+import android.content.Context
+import android.view.LayoutInflater
+import android.view.View
+import android.widget.AbsoluteLayout
+import com.airbnb.lottie.LottieAnimationView
+
+object GXAdapterLottieCreate {
+
+    fun localCreateLottieView(context: Context): View {
+        val lottieView: LottieAnimationView = LayoutInflater.from(context)
+            .inflate(R.layout.gaiax_inner_lottie_auto_play, null) as LottieAnimationView
+        lottieView.layoutParams = AbsoluteLayout.LayoutParams(
+            AbsoluteLayout.LayoutParams.MATCH_PARENT,
+            AbsoluteLayout.LayoutParams.MATCH_PARENT,
+            0,
+            0
+        )
+        return lottieView
+    }
+}

--- a/GaiaXAdapterAndroid/src/main/java/com/alibaba/gaiax/adapter/GXExtensionLottieAnimation.kt
+++ b/GaiaXAdapterAndroid/src/main/java/com/alibaba/gaiax/adapter/GXExtensionLottieAnimation.kt
@@ -16,29 +16,11 @@
 
 package com.alibaba.gaiax.adapter
 
-import android.content.Context
-import android.view.LayoutInflater
-import android.view.View
-import android.widget.AbsoluteLayout
-import com.airbnb.lottie.LottieAnimationView
 import com.alibaba.gaiax.GXRegisterCenter
 import com.alibaba.gaiax.template.animation.GXLottieAnimation
 
 class GXExtensionLottieAnimation : GXRegisterCenter.GXIExtensionLottieAnimation {
     override fun create(): GXLottieAnimation {
         return GXAdapterLottieAnimation()
-    }
-
-
-    override fun localCreateLottieView(context: Context): View {
-        val lottieView: LottieAnimationView = LayoutInflater.from(context)
-            .inflate(R.layout.gaiax_inner_lottie_auto_play, null) as LottieAnimationView
-        lottieView.layoutParams = AbsoluteLayout.LayoutParams(
-            AbsoluteLayout.LayoutParams.MATCH_PARENT,
-            AbsoluteLayout.LayoutParams.MATCH_PARENT,
-            0,
-            0
-        )
-        return lottieView
     }
 }

--- a/GaiaXAdapterAndroid/src/main/java/com/alibaba/gaiax/adapter/GXExtensionLottieAnimation.kt
+++ b/GaiaXAdapterAndroid/src/main/java/com/alibaba/gaiax/adapter/GXExtensionLottieAnimation.kt
@@ -16,11 +16,29 @@
 
 package com.alibaba.gaiax.adapter
 
+import android.content.Context
+import android.view.LayoutInflater
+import android.view.View
+import android.widget.AbsoluteLayout
+import com.airbnb.lottie.LottieAnimationView
 import com.alibaba.gaiax.GXRegisterCenter
 import com.alibaba.gaiax.template.animation.GXLottieAnimation
 
 class GXExtensionLottieAnimation : GXRegisterCenter.GXIExtensionLottieAnimation {
     override fun create(): GXLottieAnimation {
         return GXAdapterLottieAnimation()
+    }
+
+
+    override fun localCreateLottieView(context: Context): View {
+        val lottieView: LottieAnimationView = LayoutInflater.from(context)
+            .inflate(R.layout.gaiax_inner_lottie_auto_play, null) as LottieAnimationView
+        lottieView.layoutParams = AbsoluteLayout.LayoutParams(
+            AbsoluteLayout.LayoutParams.MATCH_PARENT,
+            AbsoluteLayout.LayoutParams.MATCH_PARENT,
+            0,
+            0
+        )
+        return lottieView
     }
 }

--- a/GaiaXAndroid/src/androidTest/java/com/alibaba/gaiax/GXComponentViewTest.kt
+++ b/GaiaXAndroid/src/androidTest/java/com/alibaba/gaiax/GXComponentViewTest.kt
@@ -1,5 +1,6 @@
 package com.alibaba.gaiax
 
+import android.content.Context
 import android.graphics.Color
 import android.graphics.drawable.GradientDrawable
 import android.view.View
@@ -8,18 +9,39 @@ import android.widget.ImageView
 import androidx.recyclerview.widget.RecyclerView
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.alibaba.fastjson.JSONObject
+import com.alibaba.gaiax.render.view.GXViewKey
 import com.alibaba.gaiax.render.view.basic.GXImageView
 import com.alibaba.gaiax.render.view.basic.GXText
 import com.alibaba.gaiax.render.view.basic.GXView
 import com.alibaba.gaiax.template.GXSize.Companion.dpToPx
+import com.alibaba.gaiax.template.animation.GXLottieAnimation
 import com.alibaba.gaiax.utils.GXMockUtils
 import org.junit.Assert
+import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 
 
 @RunWith(AndroidJUnit4::class)
 class GXComponentViewTest : GXBaseTest() {
+    @Before
+    fun registerLottieView(){
+
+        GXRegisterCenter.instance.registerExtensionViewSupport(GXViewKey.VIEW_TYPE_LOTTIE,::buildLottieView)
+            .registerExtensionLottieAnimation(object :GXRegisterCenter.GXIExtensionLottieAnimation{
+                override fun create(): GXLottieAnimation? {
+                    return object :GXLottieAnimation(){
+
+                    }
+                }
+            })
+    }
+
+    private fun buildLottieView(context: Context):View{
+        return View(context).apply {
+            setTag(R.id.gaiax_rv_touch,1)
+        }
+    }
 
     @Test
     fun template_merge_empty_node_with_padding() {
@@ -501,5 +523,17 @@ class GXComponentViewTest : GXBaseTest() {
         GXTemplateEngine.instance.bindData(rootView, templateData)
 
         Assert.assertEquals(true, (rootView.child(0).clipToOutline))
+    }
+
+    //Lottie单测
+    @Test
+    fun template_animation_lottie_local(){
+        val templateItem =
+            GXTemplateEngine.GXTemplateItem(GXMockUtils.context, "view", "template_animation_lottie_local")
+        val templateData = GXTemplateEngine.GXTemplateData(JSONObject())
+        val rootView = GXTemplateEngine.instance.createView(templateItem, size)
+        GXTemplateEngine.instance.bindData(rootView, templateData)
+        Assert.assertEquals(true, (rootView.childCount() == 2))
+        Assert.assertEquals(true, (rootView.child(1) .getTag(R.id.gaiax_rv_touch) == 1))
     }
 }

--- a/GaiaXAndroid/src/androidTest/java/com/alibaba/gaiax/render/view/GXViewFactoryTest.kt
+++ b/GaiaXAndroid/src/androidTest/java/com/alibaba/gaiax/render/view/GXViewFactoryTest.kt
@@ -16,13 +16,16 @@
 
 package com.alibaba.gaiax.render.view
 
+import android.content.Context
 import android.view.View
 import androidx.test.platform.app.InstrumentationRegistry
+import com.alibaba.gaiax.GXRegisterCenter
 import com.alibaba.gaiax.render.view.basic.*
 import com.alibaba.gaiax.render.view.container.GXGridView
 import com.alibaba.gaiax.render.view.container.GXScrollView
 import com.alibaba.gaiax.render.view.container.slider.GXSliderView
 import org.junit.Assert
+import org.junit.Before
 import org.junit.Test
 
 class GXViewFactoryTest {
@@ -42,10 +45,10 @@ class GXViewFactoryTest {
             true,
             GXViewFactory.createView<View>(context, GXViewKey.VIEW_TYPE_TEXT) is GXText
         )
-//        Assert.assertEquals(
-//            true,
-//            GXViewFactory.createView<View>(context, GXViewKey.VIEW_TYPE_LOTTIE) is GXLottie
-//        )
+        Assert.assertEquals(
+            true,
+            GXViewFactory.createView<View>(context, GXViewKey.VIEW_TYPE_LOTTIE) is View
+        )
         Assert.assertEquals(
             true,
             GXViewFactory.createView<View>(
@@ -86,6 +89,15 @@ class GXViewFactoryTest {
                 GXViewKey.VIEW_TYPE_CONTAINER_SLIDER
             ) is GXSliderView
         )
+    }
+
+    @Before
+    fun registerLottie(){
+        GXRegisterCenter.instance.registerExtensionViewSupport(GXViewKey.VIEW_TYPE_LOTTIE,::buildLottieView)
+    }
+
+    fun buildLottieView(context: Context): View {
+        return View(context)
     }
 
 }

--- a/GaiaXAndroid/src/main/kotlin/com/alibaba/gaiax/GXRegisterCenter.kt
+++ b/GaiaXAndroid/src/main/kotlin/com/alibaba/gaiax/GXRegisterCenter.kt
@@ -18,6 +18,7 @@ package com.alibaba.gaiax
 
 import android.content.Context
 import android.graphics.Typeface
+import android.view.View
 import android.view.ViewGroup
 import com.alibaba.fastjson.JSONArray
 import com.alibaba.fastjson.JSONObject
@@ -187,6 +188,11 @@ class GXRegisterCenter {
 
     interface GXIExtensionLottieAnimation {
         fun create(): GXLottieAnimation?
+
+        /**
+         * 提供Lottie视图给Gaiax，采用注册注入的方式是避免Gaiax直接依赖lottie组件
+         * */
+        fun localCreateLottieView(context: Context): View
     }
 
     interface GXIExtensionCompatibility {

--- a/GaiaXAndroid/src/main/kotlin/com/alibaba/gaiax/GXRegisterCenter.kt
+++ b/GaiaXAndroid/src/main/kotlin/com/alibaba/gaiax/GXRegisterCenter.kt
@@ -188,11 +188,6 @@ class GXRegisterCenter {
 
     interface GXIExtensionLottieAnimation {
         fun create(): GXLottieAnimation?
-
-        /**
-         * 提供Lottie视图给Gaiax，采用注册注入的方式是避免Gaiax直接依赖lottie组件
-         * */
-        fun localCreateLottieView(context: Context): View
     }
 
     interface GXIExtensionCompatibility {
@@ -317,6 +312,11 @@ class GXRegisterCenter {
 
     fun registerExtensionViewSupport(viewType: String, clazz: Class<*>): GXRegisterCenter {
         GXViewFactory.viewSupport[viewType] = clazz
+        return this
+    }
+
+    fun registerExtensionViewSupport(viewType: String, viewCreater: (Context) -> View): GXRegisterCenter {
+        GXViewFactory.viewUnitSupport[viewType] = viewCreater
         return this
     }
 

--- a/GaiaXAndroid/src/main/kotlin/com/alibaba/gaiax/render/node/GXNode.kt
+++ b/GaiaXAndroid/src/main/kotlin/com/alibaba/gaiax/render/node/GXNode.kt
@@ -23,6 +23,7 @@ import com.alibaba.gaiax.GXRegisterCenter
 import com.alibaba.gaiax.GXTemplateEngine
 import com.alibaba.gaiax.context.GXTemplateContext
 import com.alibaba.gaiax.template.GXLayer
+import com.alibaba.gaiax.template.GXTemplateKey
 
 /**
  * @suppress
@@ -77,6 +78,11 @@ class GXNode {
      * 同级阴影View引用
      */
     var boxLayoutView: View? = null
+
+    /**
+     * 节点上覆盖的lottieView
+     */
+    var lottieView: View? = null
 
     /**
      * 节点的模板数据
@@ -162,6 +168,10 @@ class GXNode {
 
     fun isNeedShadow(): Boolean {
         return (isViewType() || isImageType()) && templateNode.css.style.boxShadow != null
+    }
+
+    fun isNeedLottie(): Boolean {
+        return templateNode.animationBinding?.type?.equals(GXTemplateKey.GAIAX_ANIMATION_TYPE_LOTTIE,true) == true
     }
 
     fun setIdPath(parent: GXNode?, layer: GXLayer) {

--- a/GaiaXAndroid/src/main/kotlin/com/alibaba/gaiax/render/view/GXViewFactory.kt
+++ b/GaiaXAndroid/src/main/kotlin/com/alibaba/gaiax/render/view/GXViewFactory.kt
@@ -30,6 +30,7 @@ import com.alibaba.gaiax.render.view.container.slider.GXSliderView
 object GXViewFactory {
 
     internal val viewSupport: MutableMap<String, Class<*>> = mutableMapOf()
+    internal val viewUnitSupport: MutableMap<String,(Context) -> View> = mutableMapOf()
 
     init {
         viewSupport[GXViewKey.VIEW_TYPE_GAIA_TEMPLATE] = GXView::class.java
@@ -52,8 +53,10 @@ object GXViewFactory {
     fun <T : View> createView(context: Context, type: String, customViewClass: String? = null): T {
         val result = if (GXViewKey.VIEW_TYPE_CUSTOM == type && customViewClass != null) {
             newInstance<T>(customViewClass, context)
-        } else {
+        } else if (viewSupport.contains(type)){
             newInstance<T>(viewSupport[type], context)
+        } else{
+            viewUnitSupport[type]?.invoke(context)
         }
         return result as T
     }

--- a/GaiaXAndroid/src/main/kotlin/com/alibaba/gaiax/render/view/GXViewTreeCreator.kt
+++ b/GaiaXAndroid/src/main/kotlin/com/alibaba/gaiax/render/view/GXViewTreeCreator.kt
@@ -19,6 +19,7 @@ package com.alibaba.gaiax.render.view
 import android.view.View
 import android.view.ViewGroup
 import app.visly.stretch.Layout
+import com.alibaba.gaiax.GXRegisterCenter
 import com.alibaba.gaiax.context.GXTemplateContext
 import com.alibaba.gaiax.render.node.GXNode
 import com.alibaba.gaiax.render.view.basic.GXShadowLayout
@@ -85,6 +86,22 @@ class GXViewTreeCreator(gxTemplateContext: GXTemplateContext, rootNode: GXNode) 
                     parentMergeView.addView(this)
                 }
             }
+
+        //没有采用注册进ViewFactory的方式创建对象是因为lottie必须用xml形式创建。
+        if (childNode.isNeedLottie()){
+            GXRegisterCenter.instance.extensionLottieAnimation?.localCreateLottieView(context.context)?.apply {
+                this.layoutParams = GXViewLayoutParamsUtils.createLayoutParams(
+                    childNode,
+                    childLayout,
+                    mergeX,
+                    mergeY
+                )
+                childNode.lottieView = this
+                if (parentMergeView is ViewGroup) {
+                    parentMergeView.addView(this)
+                }
+            }
+        }
         return childView
     }
 }

--- a/GaiaXAndroid/src/main/kotlin/com/alibaba/gaiax/render/view/GXViewTreeCreator.kt
+++ b/GaiaXAndroid/src/main/kotlin/com/alibaba/gaiax/render/view/GXViewTreeCreator.kt
@@ -19,7 +19,6 @@ package com.alibaba.gaiax.render.view
 import android.view.View
 import android.view.ViewGroup
 import app.visly.stretch.Layout
-import com.alibaba.gaiax.GXRegisterCenter
 import com.alibaba.gaiax.context.GXTemplateContext
 import com.alibaba.gaiax.render.node.GXNode
 import com.alibaba.gaiax.render.view.basic.GXShadowLayout
@@ -89,7 +88,7 @@ class GXViewTreeCreator(gxTemplateContext: GXTemplateContext, rootNode: GXNode) 
 
         //没有采用注册进ViewFactory的方式创建对象是因为lottie必须用xml形式创建。
         if (childNode.isNeedLottie()){
-            GXRegisterCenter.instance.extensionLottieAnimation?.localCreateLottieView(context.context)?.apply {
+            GXViewFactory.createView<View>(context.context,GXViewKey.VIEW_TYPE_LOTTIE,null)?.apply {
                 this.layoutParams = GXViewLayoutParamsUtils.createLayoutParams(
                     childNode,
                     childLayout,

--- a/GaiaXAndroid/src/main/kotlin/com/alibaba/gaiax/render/view/GXViewTreeUpdate.kt
+++ b/GaiaXAndroid/src/main/kotlin/com/alibaba/gaiax/render/view/GXViewTreeUpdate.kt
@@ -54,6 +54,16 @@ open class GXViewTreeUpdate(context: GXTemplateContext, rootNode: GXNode) :
                     )
                 }
             }
+            if (childNode.isNeedLottie()){
+                childNode.lottieView?.let { lottieView ->
+                    GXViewLayoutParamsUtils.updateLayoutParams(
+                        lottieView,
+                        childLayout,
+                        mergeX,
+                        mergeY
+                    )
+                }
+            }
             GXViewLayoutParamsUtils.updateLayoutParams(targetView, childLayout, mergeX, mergeY)
         }
     }


### PR DESCRIPTION
Gaiax Lottie动画，Android实现对齐iOS

1. 支持以任意节点创建Lottie视图，并且覆盖当前View
2. 使用RegisterCenter来提供lottie视图对象给Gaiax，避免Gaiax依赖lottie
3. 使用当前节点的布局宽高位置属性来放置lottie动画视图