### PR TITLE
修复错误表达式crash问题

### DIFF
--- a/GaiaXAnalyze/GXAnalyzeCore/GXWordAnalyze.cpp
+++ b/GaiaXAnalyze/GXAnalyzeCore/GXWordAnalyze.cpp
@@ -375,7 +375,6 @@ GXATSNode scanner(int &syn, int &p, char s[], void *p_analyze) {
                 token[count] = '\0';
                 sign = "error";
                 string errorMsg = token;
-                delete[]token;
                 analyze->throwError("unknown identifier: " + errorMsg);
                 break;
             }

--- a/GaiaXiOS/GaiaXiOS/Binding/Expression/GXAnalyzeCore/GXWordAnalyze.cpp
+++ b/GaiaXiOS/GaiaXiOS/Binding/Expression/GXAnalyzeCore/GXWordAnalyze.cpp
@@ -375,7 +375,6 @@ GXATSNode scanner(int &syn, int &p, char s[], void *p_analyze) {
                 token[count] = '\0';
                 sign = "error";
                 string errorMsg = token;
-                delete[]token;
                 analyze->throwError("unknown identifier: " + errorMsg);
                 break;
             }


### PR DESCRIPTION
ios端，错误表达式会触发两次delete导致崩溃，已修复