### PR TITLE
fix: to fix GXValue

### DIFF
--- a/GaiaXTaro/packages/gaiax-taro/src/gaiax/GXExpression.tsx
+++ b/GaiaXTaro/packages/gaiax-taro/src/gaiax/GXExpression.tsx
@@ -1,5 +1,4 @@
-import computeValuePath from './GXValuePath';
-
+import getValue from "lodash/get";
 class GXExpression {
 
     desireData(expression: any, rawJson: any): any {
@@ -123,9 +122,9 @@ class GXExpression {
             }
             // GXValue
             else if (this.isValue(exp)) {
-                const result = exp.substring(2, exp.length - 1)
+                const result = exp.substring(1)
                 if (typeof rawJson == 'object') {
-                    return computeValuePath(result, rawJson);
+                    return getValue(rawJson, result, '');
                 }
                 return '';
             }
@@ -253,11 +252,11 @@ class GXExpression {
         return false;
     }
 
-    private valueRegex = /\$\{[a-zA-Z.\[\]0-9]+\}/g;
+    private valueRegex = /\$[a-zA-Z.\[\]0-9]+/g;
     private ternaryValueRegex = /\@\{/g;
 
     private isValue(expression: string) {
-        if (expression.startsWith("${") && expression.endsWith("}")) {
+        if (expression.startsWith("$")) {
             let result = expression.match(this.valueRegex)
             if (result != null && result.length == 1) {
                 return true;


### PR DESCRIPTION
- 修复绑定数据的解析规则
- [文档介绍](https://youku-gaiax.github.io/GaiaXSDK/basic/databinding.html#%E6%95%B0%E6%8D%AE%E7%BB%91%E5%AE%9A%E8%A7%84%E5%88%99) 绑定数据格式为 $data.title，非${data.a.b}
- computeValuePath方法对于解析如 $data.msgBarContentList[0].extendInfo.packages[0].couponAmount 不适用，使用[lodash.get](https://lodash.com/docs/4.17.15#get)
