### PR TITLE
Fix text padding

### DIFF
--- a/GaiaXiOS/GaiaXiOS/Component/Node/GXTextNode.m
+++ b/GaiaXiOS/GaiaXiOS/Component/Node/GXTextNode.m
@@ -451,7 +451,11 @@ const NSUInteger GXTextMaxWidth = 1080;
     } else if (lineNum == 1) {
         // 等于1行时，动态计算宽度
         CTLineRef lineRef = (__bridge CTLineRef)[linesRef firstObject];
-        width = width = CTLineGetTypographicBounds(lineRef, NULL, NULL, NULL);
+        // 通过kCTLineBoundsIncludeLanguageExtents来确保不同的语言都有足够的空间
+        CGRect rect = CTLineGetBoundsWithOptions(lineRef,
+                                                 kCTLineBoundsExcludeTypographicLeading|
+                                                 kCTLineBoundsExcludeTypographicShifts);
+         width = rect.size.width;
     } else {
         // 大于1行时,行宽直接用最大宽度
         width = maxWidth;

--- a/GaiaXiOS/GaiaXiOS/Component/Node/GXTextNode.m
+++ b/GaiaXiOS/GaiaXiOS/Component/Node/GXTextNode.m
@@ -451,9 +451,7 @@ const NSUInteger GXTextMaxWidth = 1080;
     } else if (lineNum == 1) {
         // 等于1行时，动态计算宽度
         CTLineRef lineRef = (__bridge CTLineRef)[linesRef firstObject];
-        // 通过kCTLineBoundsIncludeLanguageExtents来确保不同的语言都有足够的空间
-        CGRect rect = CTLineGetBoundsWithOptions(lineRef,  kCTLineBoundsIncludeLanguageExtents);
-        width = rect.size.width;
+        width = width = CTLineGetTypographicBounds(lineRef, NULL, NULL, NULL);
     } else {
         // 大于1行时,行宽直接用最大宽度
         width = maxWidth;


### PR DESCRIPTION
kCTLineBoundsIncludeLanguageExtents 使用这个属性之后，在实际应用场景发现text的内边距会加大，导致与UI标注相差较大。先用来的实现，来确保UI标注相同。[相关issues](https://github.com/alibaba/GaiaX/issues/365)