### PR TITLE
export load binary gaia file for custom source

### DIFF
--- a/GaiaXiOS/GaiaXiOS/Template/Loader/GXTemplateReader.h
+++ b/GaiaXiOS/GaiaXiOS/Template/Loader/GXTemplateReader.h
@@ -32,6 +32,13 @@ NS_ASSUME_NONNULL_BEGIN
                                             templateVersion:(NSString * _Nullable)templateVersion;
 
 
+/// 读取二进制模板信息
+/// @param filePath  二进制文件路径
+/// @param templateId 模板id
+/// @param templateVersion 模板version
+- (NSMutableDictionary *)loadBinaryTemplateWithFilePath:(NSString *)filePath
+                                             templateId:(NSString * _Nonnull)templateId
+                                        templateVersion:(NSString * _Nullable)templateVersion;
 
 /// 读取模板信息
 /// @param templateInfo 模板具体内容


### PR DESCRIPTION
这个export 是为了自定义TemplateSource的时候,能直接通过自定义路径解析二进制数据。原有的方法会去gaiax定义的路径去获取
```objc
- (NSDictionary *)readTemplateContenttWithFolderPath:(NSString * _Nonnull)folderPath
                                          templateId:(NSString * _Nonnull)templateId
                                     templateVersion:(NSString * _Nullable)templateVersion {
···
    //获取二进制文件路径
    NSString *gaiaXPath = [GXTemplatePathHelper loadBinaryFilePathWithFolderPath:folderPath fileName:templateId fileType:nil];
···
}

```