### PR TITLE
Expression decimal fix 0906. 

### DIFF
--- a/GaiaXAnalyze/GXAnalyzeAndroid/src/androidTest/kotlin/com/alibaba/gaiax/analyze/GXAnalyzeTest.kt
+++ b/GaiaXAnalyze/GXAnalyzeAndroid/src/androidTest/kotlin/com/alibaba/gaiax/analyze/GXAnalyzeTest.kt
@@ -63,12 +63,13 @@ class GXAnalyzeTest {
                 this["array"] = JSONArray()
             }
         }
-
-        Assert.assertEquals(null, instance.getResult("\$data.stringEmpty", testData))
-        Assert.assertEquals("", instance.getResult("''", testData))
-        Assert.assertEquals(null, instance.getResult("", testData))
-        Assert.assertEquals(null, instance.getResult("null", testData))
-        Assert.assertEquals(0f, instance.getResult("size(null)", JSONObject()))
+        repeat(10) {
+            Assert.assertEquals(null, instance.getResult("\$data.stringEmpty", testData))
+            Assert.assertEquals("", instance.getResult("''", testData))
+            Assert.assertEquals(null, instance.getResult("", testData))
+            Assert.assertEquals(null, instance.getResult("null", testData))
+            Assert.assertEquals(0f, instance.getResult("size(null)", JSONObject()))
+        }
     }
 
     @Test
@@ -81,105 +82,176 @@ class GXAnalyzeTest {
                 this["array"] = JSONArray()
             }
         }
-        Assert.assertEquals(100000000001F, instance.getResult("100000000000+1.0", testData))
-        Assert.assertEquals(9223372036854775802L, instance.getResult("9223372036854775801 + 1", testData))
-        Assert.assertEquals(10001L, instance.getResult("10000+1", testData))
-        Assert.assertEquals(100001L, instance.getResult("100000+1", testData))
-        Assert.assertEquals(1000001L, instance.getResult("1000000+1", testData))
-        Assert.assertEquals(10000001L, instance.getResult("10000000+1", testData))
-        Assert.assertEquals(100000001L, instance.getResult("100000000+1", testData))
-        Assert.assertEquals(1000000001L, instance.getResult("1000000000+1", testData))
-        Assert.assertEquals(10000000001L, instance.getResult("10000000000+1", testData))
-        Assert.assertEquals(100000000001L, instance.getResult("100000000000+1", testData))
-        Assert.assertEquals(1000000000001L, instance.getResult("1000000000000+1", testData))
-        Assert.assertEquals(10000000000001L, instance.getResult("10000000000000+1", testData))
-        Assert.assertEquals(100000000000001L, instance.getResult("100000000000000+1", testData))
-        Assert.assertEquals(10000000000000001L, instance.getResult("10000000000000000+1", testData))
-        Assert.assertEquals(100000000000000001L, instance.getResult("100000000000000000+1", testData))
-        Assert.assertEquals(1000000000000000001L, instance.getResult("1000000000000000000+1", testData))
+        repeat(10) {
+            Assert.assertEquals(100000000001F, instance.getResult("100000000000+1.0", testData))
+            Assert.assertEquals(
+                9223372036854775802L,
+                instance.getResult("9223372036854775801 + 1", testData)
+            )
+            Assert.assertEquals(10001L, instance.getResult("10000+1", testData))
+            Assert.assertEquals(100001L, instance.getResult("100000+1", testData))
+            Assert.assertEquals(1000001L, instance.getResult("1000000+1", testData))
+            Assert.assertEquals(10000001L, instance.getResult("10000000+1", testData))
+            Assert.assertEquals(100000001L, instance.getResult("100000000+1", testData))
+            Assert.assertEquals(1000000001L, instance.getResult("1000000000+1", testData))
+            Assert.assertEquals(10000000001L, instance.getResult("10000000000+1", testData))
+            Assert.assertEquals(100000000001L, instance.getResult("100000000000+1", testData))
+            Assert.assertEquals(1000000000001L, instance.getResult("1000000000000+1", testData))
+            Assert.assertEquals(10000000000001L, instance.getResult("10000000000000+1", testData))
+            Assert.assertEquals(100000000000001L, instance.getResult("100000000000000+1", testData))
+            Assert.assertEquals(
+                10000000000000001L,
+                instance.getResult("10000000000000000+1", testData)
+            )
+            Assert.assertEquals(
+                100000000000000001L,
+                instance.getResult("100000000000000000+1", testData)
+            )
+            Assert.assertEquals(
+                1000000000000000001L,
+                instance.getResult("1000000000000000000+1", testData)
+            )
 
-        Assert.assertEquals(100000000000F, instance.getResult("100000000001-1.0", testData))
-        Assert.assertEquals(9223372036854775802L, instance.getResult("9223372036854775803 - 1", testData))
-        Assert.assertEquals(10000L, instance.getResult("10001-1", testData))
-        Assert.assertEquals(100001L, instance.getResult("100002-1", testData))
-        Assert.assertEquals(1000001L, instance.getResult("1000002-1", testData))
-        Assert.assertEquals(10000001L, instance.getResult("10000002-1", testData))
-        Assert.assertEquals(100000001L, instance.getResult("100000002-1", testData))
-        Assert.assertEquals(1000000001L, instance.getResult("1000000002-1", testData))
-        Assert.assertEquals(10000000001L, instance.getResult("10000000002-1", testData))
-        Assert.assertEquals(100000000001L, instance.getResult("100000000002-1", testData))
-        Assert.assertEquals(1000000000001L, instance.getResult("1000000000002-1", testData))
-        Assert.assertEquals(10000000000001L, instance.getResult("10000000000002-1", testData))
-        Assert.assertEquals(100000000000001L, instance.getResult("100000000000002-1", testData))
-        Assert.assertEquals(10000000000000001L, instance.getResult("10000000000000002-1", testData))
-        Assert.assertEquals(100000000000000001L, instance.getResult("100000000000000002-1", testData))
-        Assert.assertEquals(1000000000000000001L, instance.getResult("1000000000000000002-1", testData))
-
-        Assert.assertEquals(200000000000F, instance.getResult("100000000000 * 2.0", testData))
-        Assert.assertEquals(20000L, instance.getResult("10000 * 2", testData))
-        Assert.assertEquals(200000L, instance.getResult("100000 * 2", testData))
-        Assert.assertEquals(2000000L, instance.getResult("1000000 * 2", testData))
-        Assert.assertEquals(20000000L, instance.getResult("10000000 * 2", testData))
-        Assert.assertEquals(200000000L, instance.getResult("100000000 * 2", testData))
-        Assert.assertEquals(2000000000L, instance.getResult("1000000000 * 2", testData))
-        Assert.assertEquals(20000000000L, instance.getResult("10000000000 * 2", testData))
-        Assert.assertEquals(200000000000L, instance.getResult("100000000000 * 2", testData))
-        Assert.assertEquals(2000000000000L, instance.getResult("1000000000000 * 2", testData))
-        Assert.assertEquals(20000000000000L, instance.getResult("10000000000000 * 2", testData))
-        Assert.assertEquals(200000000000000L, instance.getResult("100000000000000 * 2", testData))
-        Assert.assertEquals(20000000000000000L, instance.getResult("10000000000000000 * 2", testData))
-        Assert.assertEquals(200000000000000000L, instance.getResult("100000000000000000 * 2", testData))
-        Assert.assertEquals(2000000000000000000L, instance.getResult("1000000000000000000 * 2", testData))
-
-        Assert.assertEquals(62.5F, instance.getResult("125.0 / 2", testData))
-        Assert.assertEquals(5000L, instance.getResult("10000 / 2", testData))
-        Assert.assertEquals(50000L, instance.getResult("100000 / 2", testData))
-        Assert.assertEquals(500000L, instance.getResult("1000000 / 2", testData))
-        Assert.assertEquals(5000000L, instance.getResult("10000000 / 2", testData))
-        Assert.assertEquals(50000000L, instance.getResult("100000000 / 2", testData))
-        Assert.assertEquals(500000000L, instance.getResult("1000000000 / 2", testData))
-        Assert.assertEquals(5000000000L, instance.getResult("10000000000 / 2", testData))
-        Assert.assertEquals(50000000000L, instance.getResult("100000000000 / 2", testData))
-        Assert.assertEquals(500000000000L, instance.getResult("1000000000000 / 2", testData))
-        Assert.assertEquals(5000000000000L, instance.getResult("10000000000000 / 2", testData))
-        Assert.assertEquals(50000000000000L, instance.getResult("100000000000000 / 2", testData))
-        Assert.assertEquals(5000000000000000L, instance.getResult("10000000000000000 / 2", testData))
-        Assert.assertEquals(50000000000000000L, instance.getResult("100000000000000000 / 2", testData))
-        Assert.assertEquals(500000000000000000L, instance.getResult("1000000000000000000 / 2", testData))
-        Assert.assertEquals(500000.5F, instance.getResult("1000001.0 / 2", testData))
-        Assert.assertEquals(500000000000.5F, instance.getResult("1000000000001.0 / 2", testData))
-        Assert.assertEquals(500000000000000000.5F, instance.getResult("1000000000000000001.0 / 2", testData))
-
-
-        Assert.assertEquals(30L, instance.getResult("80 % 50", testData))
-        Assert.assertEquals(300L, instance.getResult("800 % 500", testData))
-        Assert.assertEquals(3000L, instance.getResult("8000 % 5000", testData))
-        Assert.assertEquals(30000L, instance.getResult("80000 % 50000", testData))
-        Assert.assertEquals(300000L, instance.getResult("800000 % 500000", testData))
-        Assert.assertEquals(3000000L, instance.getResult("8000000 % 5000000", testData))
-        Assert.assertEquals(30000000L, instance.getResult("80000000 % 50000000", testData))
-        Assert.assertEquals(300000000L, instance.getResult("800000000 % 500000000", testData))
-        Assert.assertEquals(3000000000L, instance.getResult("8000000000 % 5000000000", testData))
-        Assert.assertEquals(30000000000L, instance.getResult("80000000000 % 50000000000", testData))
-        Assert.assertEquals(300000000000L, instance.getResult("800000000000 % 500000000000", testData))
-        Assert.assertEquals(3000000000000L, instance.getResult("8000000000000 % 5000000000000", testData))
-        Assert.assertEquals(30000000000000L, instance.getResult("80000000000000 % 50000000000000", testData))
-        Assert.assertEquals(300000000000000L, instance.getResult("800000000000000 % 500000000000000", testData))
-        Assert.assertEquals(3000000000000000L, instance.getResult("8000000000000000 % 5000000000000000", testData))
-
-
-        Assert.assertEquals(10000L, instance.getResult("10000", testData))
-        Assert.assertEquals(10f, instance.getResult("10.000", testData))
-        Assert.assertEquals(100f, instance.getResult("100.00", testData))
-        Assert.assertEquals(1000f, instance.getResult("1000.0", testData))
-        Assert.assertEquals(1001f, instance.getResult("1001.0", testData))
-        Assert.assertEquals(1111L, instance.getResult("1111", testData))
-        Assert.assertEquals(11110L, instance.getResult("11110", testData))
-        Assert.assertEquals(20000L, instance.getResult("10000+10000", testData))
-        Assert.assertEquals(
-            26L,
-            instance.getResult("1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1", testData)
-        )
+            Assert.assertEquals(100000000000F, instance.getResult("100000000001-1.0", testData))
+            Assert.assertEquals(
+                9223372036854775802L,
+                instance.getResult("9223372036854775803 - 1", testData)
+            )
+            Assert.assertEquals(10000L, instance.getResult("10001-1", testData))
+            Assert.assertEquals(100001L, instance.getResult("100002-1", testData))
+            Assert.assertEquals(1000001L, instance.getResult("1000002-1", testData))
+            Assert.assertEquals(10000001L, instance.getResult("10000002-1", testData))
+            Assert.assertEquals(100000001L, instance.getResult("100000002-1", testData))
+            Assert.assertEquals(1000000001L, instance.getResult("1000000002-1", testData))
+            Assert.assertEquals(10000000001L, instance.getResult("10000000002-1", testData))
+            Assert.assertEquals(100000000001L, instance.getResult("100000000002-1", testData))
+            Assert.assertEquals(1000000000001L, instance.getResult("1000000000002-1", testData))
+            Assert.assertEquals(10000000000001L, instance.getResult("10000000000002-1", testData))
+            Assert.assertEquals(100000000000001L, instance.getResult("100000000000002-1", testData))
+            Assert.assertEquals(
+                10000000000000001L,
+                instance.getResult("10000000000000002-1", testData)
+            )
+            Assert.assertEquals(
+                100000000000000001L,
+                instance.getResult("100000000000000002-1", testData)
+            )
+            Assert.assertEquals(
+                1000000000000000001L,
+                instance.getResult("1000000000000000002-1", testData)
+            )
+            Assert.assertEquals(200000000000F, instance.getResult("100000000000 * 2.0", testData))
+            Assert.assertEquals(20000L, instance.getResult("10000 * 2", testData))
+            Assert.assertEquals(200000L, instance.getResult("100000 * 2", testData))
+            Assert.assertEquals(2000000L, instance.getResult("1000000 * 2", testData))
+            Assert.assertEquals(20000000L, instance.getResult("10000000 * 2", testData))
+            Assert.assertEquals(200000000L, instance.getResult("100000000 * 2", testData))
+            Assert.assertEquals(2000000000L, instance.getResult("1000000000 * 2", testData))
+            Assert.assertEquals(20000000000L, instance.getResult("10000000000 * 2", testData))
+            Assert.assertEquals(200000000000L, instance.getResult("100000000000 * 2", testData))
+            Assert.assertEquals(2000000000000L, instance.getResult("1000000000000 * 2", testData))
+            Assert.assertEquals(20000000000000L, instance.getResult("10000000000000 * 2", testData))
+            Assert.assertEquals(
+                200000000000000L,
+                instance.getResult("100000000000000 * 2", testData)
+            )
+            Assert.assertEquals(
+                20000000000000000L,
+                instance.getResult("10000000000000000 * 2", testData)
+            )
+            Assert.assertEquals(
+                200000000000000000L,
+                instance.getResult("100000000000000000 * 2", testData)
+            )
+            Assert.assertEquals(
+                2000000000000000000L,
+                instance.getResult("1000000000000000000 * 2", testData)
+            )
+            Assert.assertEquals(62.5F, instance.getResult("125.0 / 2", testData))
+            Assert.assertEquals(5000L, instance.getResult("10000 / 2", testData))
+            Assert.assertEquals(50000L, instance.getResult("100000 / 2", testData))
+            Assert.assertEquals(500000L, instance.getResult("1000000 / 2", testData))
+            Assert.assertEquals(5000000L, instance.getResult("10000000 / 2", testData))
+            Assert.assertEquals(50000000L, instance.getResult("100000000 / 2", testData))
+            Assert.assertEquals(500000000L, instance.getResult("1000000000 / 2", testData))
+            Assert.assertEquals(5000000000L, instance.getResult("10000000000 / 2", testData))
+            Assert.assertEquals(50000000000L, instance.getResult("100000000000 / 2", testData))
+            Assert.assertEquals(500000000000L, instance.getResult("1000000000000 / 2", testData))
+            Assert.assertEquals(5000000000000L, instance.getResult("10000000000000 / 2", testData))
+            Assert.assertEquals(
+                50000000000000L,
+                instance.getResult("100000000000000 / 2", testData)
+            )
+            Assert.assertEquals(
+                5000000000000000L,
+                instance.getResult("10000000000000000 / 2", testData)
+            )
+            Assert.assertEquals(
+                50000000000000000L,
+                instance.getResult("100000000000000000 / 2", testData)
+            )
+            Assert.assertEquals(
+                500000000000000000L,
+                instance.getResult("1000000000000000000 / 2", testData)
+            )
+            Assert.assertEquals(500000.5F, instance.getResult("1000001.0 / 2", testData))
+            Assert.assertEquals(
+                500000000000.5F,
+                instance.getResult("1000000000001.0 / 2", testData)
+            )
+            Assert.assertEquals(
+                500000000000000000.5F,
+                instance.getResult("1000000000000000001.0 / 2", testData)
+            )
+            Assert.assertEquals(30L, instance.getResult("80 % 50", testData))
+            Assert.assertEquals(300L, instance.getResult("800 % 500", testData))
+            Assert.assertEquals(3000L, instance.getResult("8000 % 5000", testData))
+            Assert.assertEquals(30000L, instance.getResult("80000 % 50000", testData))
+            Assert.assertEquals(300000L, instance.getResult("800000 % 500000", testData))
+            Assert.assertEquals(3000000L, instance.getResult("8000000 % 5000000", testData))
+            Assert.assertEquals(30000000L, instance.getResult("80000000 % 50000000", testData))
+            Assert.assertEquals(300000000L, instance.getResult("800000000 % 500000000", testData))
+            Assert.assertEquals(
+                3000000000L,
+                instance.getResult("8000000000 % 5000000000", testData)
+            )
+            Assert.assertEquals(
+                30000000000L,
+                instance.getResult("80000000000 % 50000000000", testData)
+            )
+            Assert.assertEquals(
+                300000000000L,
+                instance.getResult("800000000000 % 500000000000", testData)
+            )
+            Assert.assertEquals(
+                3000000000000L,
+                instance.getResult("8000000000000 % 5000000000000", testData)
+            )
+            Assert.assertEquals(
+                30000000000000L,
+                instance.getResult("80000000000000 % 50000000000000", testData)
+            )
+            Assert.assertEquals(
+                300000000000000L,
+                instance.getResult("800000000000000 % 500000000000000", testData)
+            )
+            Assert.assertEquals(
+                3000000000000000L,
+                instance.getResult("8000000000000000 % 5000000000000000", testData)
+            )
+            Assert.assertEquals(10000L, instance.getResult("10000", testData))
+            Assert.assertEquals(10f, instance.getResult("10.000", testData))
+            Assert.assertEquals(100f, instance.getResult("100.00", testData))
+            Assert.assertEquals(1000f, instance.getResult("1000.0", testData))
+            Assert.assertEquals(1001f, instance.getResult("1001.0", testData))
+            Assert.assertEquals(1111L, instance.getResult("1111", testData))
+            Assert.assertEquals(11110L, instance.getResult("11110", testData))
+            Assert.assertEquals(20000L, instance.getResult("10000+10000", testData))
+            Assert.assertEquals(
+                26L,
+                instance.getResult("1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1", testData)
+            )
+        }
     }
 
     @Test
@@ -193,16 +265,20 @@ class GXAnalyzeTest {
                 this["array"] = JSONArray()
             }
         }
-        Assert.assertEquals(null, instance.getResult("env('testWrong')", null))
-        Assert.assertEquals(2L, instance.getResult("env('testWrong') > env('testWrong') ? 1 : 2", null))
-        Assert.assertEquals(false, instance.getResult("env('isiOS')", null))
-        Assert.assertEquals(true, instance.getResult("env('isAndroid')", null))
-
-        Assert.assertEquals(4f, instance.getResult("size('1234')", testData))
-        Assert.assertEquals(0f, instance.getResult("size(\$data.map)", testData))
-        Assert.assertEquals(0f, instance.getResult("size(\$data.array)", testData))
-        Assert.assertEquals(3f, instance.getResult("size(\$\$)", testData))
-        Assert.assertEquals(5f, instance.getResult("size('1234')+1", testData))
+        repeat(10) {
+            Assert.assertEquals(null, instance.getResult("env('testWrong')", null))
+            Assert.assertEquals(
+                2L,
+                instance.getResult("env('testWrong') > env('testWrong') ? 1 : 2", null)
+            )
+            Assert.assertEquals(false, instance.getResult("env('isiOS')", null))
+            Assert.assertEquals(true, instance.getResult("env('isAndroid')", null))
+            Assert.assertEquals(4f, instance.getResult("size('1234')", testData))
+            Assert.assertEquals(0f, instance.getResult("size(\$data.map)", testData))
+            Assert.assertEquals(0f, instance.getResult("size(\$data.array)", testData))
+            Assert.assertEquals(3f, instance.getResult("size(\$\$)", testData))
+            Assert.assertEquals(5f, instance.getResult("size('1234')+1", testData))
+        }
     }
 
     @Test
@@ -215,9 +291,10 @@ class GXAnalyzeTest {
                 this["array"] = JSONArray()
             }
         }
-
-        Assert.assertEquals(true, instance.getResult("\$data.map", testData) is JSONObject)
-        Assert.assertEquals(true, instance.getResult("\$data.array", testData) is JSONArray)
+        repeat(10) {
+            Assert.assertEquals(true, instance.getResult("\$data.map", testData) is JSONObject)
+            Assert.assertEquals(true, instance.getResult("\$data.array", testData) is JSONArray)
+        }
     }
 
     //
@@ -231,10 +308,11 @@ class GXAnalyzeTest {
                 this["array"] = JSONArray()
             }
         }
-
-        Assert.assertEquals(0L, instance.getResult("2%2", testData))
-        Assert.assertEquals(0L, instance.getResult("3%-1", testData))
-        Assert.assertEquals(1L, instance.getResult("3%2", testData))
+        repeat(10) {
+            Assert.assertEquals(0L, instance.getResult("2%2", testData))
+            Assert.assertEquals(0L, instance.getResult("3%-1", testData))
+            Assert.assertEquals(1L, instance.getResult("3%2", testData))
+        }
     }
 
     @Test
@@ -247,23 +325,27 @@ class GXAnalyzeTest {
                 this["array"] = JSONArray()
             }
         }
-
-        Assert.assertEquals(10f, instance.getResult("\$eight+2", testData))
-        Assert.assertEquals(16f, instance.getResult("\$eight+\$eight", testData))
-        Assert.assertEquals(10L, instance.getResult("1+2+3+4", testData))
-        Assert.assertEquals(1L, instance.getResult("0+1", testData))
-        Assert.assertEquals("abcd", instance.getResult("'ab'+'cd'", testData))
-        Assert.assertEquals("1231", instance.getResult("'123' + 1", testData))
-        Assert.assertEquals("1231", instance.getResult("'1' + 231", testData))
-        Assert.assertEquals("1231.000", instance.getResult("'123' + 1.000", testData))
-        Assert.assertEquals("1231.001", instance.getResult("'123' + 1.001", testData))
-        Assert.assertEquals("1231.001000", instance.getResult("'123' + 1.001000", testData))
-        Assert.assertEquals("123.001.001000", instance.getResult("'123.00' + 1.001000", testData))
-        Assert.assertEquals("1230.000", instance.getResult("'123' + 0.000", testData))
-        Assert.assertEquals("1230.001", instance.getResult("'123' + 0.001", testData))
-        Assert.assertEquals("123.0001", instance.getResult("123.000 + '1'", testData))
-        Assert.assertEquals("123.0011", instance.getResult("123.001 + '1'", testData))
-        Assert.assertEquals("123.0011.0", instance.getResult("123.001 + '1.0'", testData))
+        repeat(10) {
+            Assert.assertEquals(10f, instance.getResult("\$eight+2", testData))
+            Assert.assertEquals(16f, instance.getResult("\$eight+\$eight", testData))
+            Assert.assertEquals(10L, instance.getResult("1+2+3+4", testData))
+            Assert.assertEquals(1L, instance.getResult("0+1", testData))
+            Assert.assertEquals("abcd", instance.getResult("'ab'+'cd'", testData))
+            Assert.assertEquals("1231", instance.getResult("'123' + 1", testData))
+            Assert.assertEquals("1231", instance.getResult("'1' + 231", testData))
+            Assert.assertEquals("1231.000", instance.getResult("'123' + 1.000", testData))
+            Assert.assertEquals("1231.001", instance.getResult("'123' + 1.001", testData))
+            Assert.assertEquals("1231.001000", instance.getResult("'123' + 1.001000", testData))
+            Assert.assertEquals(
+                "123.001.001000",
+                instance.getResult("'123.00' + 1.001000", testData)
+            )
+            Assert.assertEquals("1230.000", instance.getResult("'123' + 0.000", testData))
+            Assert.assertEquals("1230.001", instance.getResult("'123' + 0.001", testData))
+            Assert.assertEquals("123.0001", instance.getResult("123.000 + '1'", testData))
+            Assert.assertEquals("123.0011", instance.getResult("123.001 + '1'", testData))
+            Assert.assertEquals("123.0011.0", instance.getResult("123.001 + '1.0'", testData))
+        }
     }
 
     @Test
@@ -276,15 +358,16 @@ class GXAnalyzeTest {
                 this["array"] = JSONArray()
             }
         }
-
-        Assert.assertEquals(3L, instance.getResult("4-1", testData))
-        Assert.assertEquals(-1L, instance.getResult("1-2", testData))
-        Assert.assertEquals(-1L, instance.getResult("0-1", testData))
-        Assert.assertEquals(-2f, instance.getResult("\$eight-10", testData))
-        Assert.assertEquals(2f, instance.getResult("10-\$eight", testData))
-        Assert.assertEquals(0f, instance.getResult("8-\$eight", testData))
-        Assert.assertEquals(-8f, instance.getResult("0-\$eight", testData))
-        Assert.assertEquals(0f, instance.getResult("\$eight-\$eight", testData))
+        repeat(10) {
+            Assert.assertEquals(3L, instance.getResult("4-1", testData))
+            Assert.assertEquals(-1L, instance.getResult("1-2", testData))
+            Assert.assertEquals(-1L, instance.getResult("0-1", testData))
+            Assert.assertEquals(-2f, instance.getResult("\$eight-10", testData))
+            Assert.assertEquals(2f, instance.getResult("10-\$eight", testData))
+            Assert.assertEquals(0f, instance.getResult("8-\$eight", testData))
+            Assert.assertEquals(-8f, instance.getResult("0-\$eight", testData))
+            Assert.assertEquals(0f, instance.getResult("\$eight-\$eight", testData))
+        }
     }
 
     @Test
@@ -297,22 +380,189 @@ class GXAnalyzeTest {
                 this["array"] = JSONArray()
             }
         }
+        repeat(10) {
+            Assert.assertEquals(0L, instance.getResult("0*2", testData))
+            Assert.assertEquals(-2L, instance.getResult("-1*2", testData))
+            Assert.assertEquals(-2L, instance.getResult("2*-1", testData))
+            Assert.assertEquals(-1L, instance.getResult("+1*-1", testData))
+            Assert.assertEquals(2L, instance.getResult("2*+1", testData))
+            Assert.assertEquals(4.4f, instance.getResult("2.2*2", testData))
+            Assert.assertEquals(-4.4f, instance.getResult("-2.2*2", testData))
+            Assert.assertEquals(-8f, instance.getResult("\$eight*-1", testData))
+            Assert.assertEquals(64f, instance.getResult("\$eight*\$eight", testData))
+            Assert.assertEquals(16f, instance.getResult("\$eight*2", testData))
+            Assert.assertEquals(1L, instance.getResult("1*1", testData))
+            Assert.assertEquals(true, instance.getResult("(1+1)>1 ? 1>0 : 2<3", testData))
+            Assert.assertEquals(true, instance.getResult("5%3 == 2", testData))
+            Assert.assertEquals(true, instance.getResult("0-2==-2", testData))
+            Assert.assertEquals(true, instance.getResult("1.0/2 == 0.5", testData))
 
-        Assert.assertEquals(0L, instance.getResult("0*2", testData))
-        Assert.assertEquals(-2L, instance.getResult("-1*2", testData))
-        Assert.assertEquals(-2L, instance.getResult("2*-1", testData))
-        Assert.assertEquals(-1L, instance.getResult("+1*-1", testData))
-        Assert.assertEquals(2L, instance.getResult("2*+1", testData))
-        Assert.assertEquals(4.4f, instance.getResult("2.2*2", testData))
-        Assert.assertEquals(-4.4f, instance.getResult("-2.2*2", testData))
-        Assert.assertEquals(-8f, instance.getResult("\$eight*-1", testData))
-        Assert.assertEquals(64f, instance.getResult("\$eight*\$eight", testData))
-        Assert.assertEquals(16f, instance.getResult("\$eight*2", testData))
-        Assert.assertEquals(1L, instance.getResult("1*1", testData))
-        Assert.assertEquals(true, instance.getResult("(1+1)>1 ? 1>0 : 2<3", testData))
-        Assert.assertEquals(true, instance.getResult("5%3 == 2", testData))
-        Assert.assertEquals(true, instance.getResult("0-2==-2", testData))
-        Assert.assertEquals(true, instance.getResult("1.0/2 == 0.5", testData))
+            Assert.assertEquals(110.2F, instance.getResult("10.2 + 100", testData))
+            Assert.assertEquals("110.2", instance.getResult("10.2 + 100 + ''", testData))
+            Assert.assertEquals("10.21", instance.getResult("10.21 + ''", testData))
+            Assert.assertEquals("10.212", instance.getResult("10.21 + '2'", testData))
+            Assert.assertEquals("9.2", instance.getResult("10.2-1 + ''", testData))
+            Assert.assertEquals("20.22", instance.getResult("10.22+10 + ''", testData))
+            Assert.assertEquals("20.2123456", instance.getResult("10.2123456+10.0 + ''", testData))
+            Assert.assertEquals(20.2123456F, instance.getResult("10.2123456+10.0", testData))
+            Assert.assertEquals("20.2", instance.getResult("10.2+10 + ''", testData))
+            Assert.assertEquals("20.4", instance.getResult("10.2*2 + ''", testData))
+            Assert.assertEquals("5.1", instance.getResult("10.2/2 + ''", testData))
+            Assert.assertEquals("3.1", instance.getResult("10.9%3.9 + ''", testData))
+            Assert.assertEquals("0.5", instance.getResult("2.5%2 + ''", testData))
+            Assert.assertEquals("21.22", instance.getResult("10.22+10+1.0+1.1-1.1 + ''", testData))
+            Assert.assertEquals(22.32F, instance.getResult("10.22+10+1.0+1.1", testData))
+            Assert.assertEquals(10.1F, instance.getResult("20.2-10.1", testData))
+            Assert.assertEquals(5.5F, instance.getResult("15.5%10", testData))
+            Assert.assertEquals(6.25F, instance.getResult("2.50*2.50", testData))
+            Assert.assertEquals(5.0625F, instance.getResult("2.2500*2.2500", testData))
+            Assert.assertEquals("5.96959188", instance.getResult("4.96959188+1 + ''", testData))
+            Assert.assertEquals(4.938262F, instance.getResult("2.222220*2.222220", testData))
+            Assert.assertEquals("4.969592", instance.getResult("2.2220*2.236540 + '' ", testData))
+            Assert.assertEquals("22.32", instance.getResult("10.22+10+1.0+1.1 + ''", testData))
+            Assert.assertEquals("1.0000000", instance.getResult("1.0000000 + '' ", testData))
+            Assert.assertEquals("2.0000000", instance.getResult("1.0000000 + 1.0000000 + '' ", testData))
+            Assert.assertEquals("1.0000000", instance.getResult("1.0000000 * 1.0000000 + '' ", testData))
+            //加法
+            Assert.assertEquals(20.3F, instance.getResult("10.1+ 10.2", testData))
+            Assert.assertEquals(20.03F, instance.getResult("10.01+ 10.02", testData))
+            Assert.assertEquals(20.003F, instance.getResult("10.001+ 10.002", testData))
+            Assert.assertEquals(20.0003F, instance.getResult("10.0001+ 10.0002", testData))
+            Assert.assertEquals(20.00003F, instance.getResult("10.00001+ 10.00002", testData))
+            Assert.assertEquals(20.000003F, instance.getResult("10.000001+ 10.000002", testData))
+            Assert.assertEquals(20.0000003F, instance.getResult("10.0000001+ 10.0000002", testData))
+            Assert.assertEquals(20.00000003F, instance.getResult("10.00000001+ 10.00000002", testData))
+            Assert.assertEquals(20.000000003F, instance.getResult("10.000000001+ 10.000000002", testData))
+            Assert.assertEquals(20.0000000003F, instance.getResult("10.0000000001+ 10.0000000002", testData))
+            Assert.assertEquals(20.00000000003F, instance.getResult("10.00000000001+ 10.00000000002", testData))
+            Assert.assertEquals(20.000000000003F, instance.getResult("10.000000000001+ 10.000000000002", testData))
+            Assert.assertEquals("20.3", instance.getResult("10.1+ 10.2 + ''", testData))
+            Assert.assertEquals("20.03", instance.getResult("10.01+ 10.02  + ''", testData))
+            Assert.assertEquals("20.003", instance.getResult("10.001+ 10.002  + ''", testData))
+            Assert.assertEquals("20.0003", instance.getResult("10.0001+ 10.0002  + ''", testData))
+            Assert.assertEquals("20.00003", instance.getResult("10.00001+ 10.00002  + ''", testData))
+            Assert.assertEquals("20.000003", instance.getResult("10.000001+ 10.000002  + ''", testData))
+            Assert.assertEquals("20.0000003", instance.getResult("10.0000001+ 10.0000002  + ''", testData))
+            Assert.assertEquals("20.00000003", instance.getResult("10.00000001+ 10.00000002  + ''", testData))
+            Assert.assertEquals("20.000000003", instance.getResult("10.000000001+ 10.000000002  + ''", testData))
+            Assert.assertEquals("20.0000000003", instance.getResult("10.0000000001+ 10.0000000002  + ''", testData))
+            Assert.assertEquals("20.00000000003", instance.getResult("10.00000000001+ 10.00000000002  + ''", testData))
+            Assert.assertEquals("20.000000000003", instance.getResult("10.000000000001+ 10.000000000002  + ''", testData))
+            //减法
+            Assert.assertEquals(20.3F, instance.getResult("30.5- 10.2", testData))
+            Assert.assertEquals(20.03F, instance.getResult("30.05- 10.02", testData))
+            Assert.assertEquals(20.003F, instance.getResult("30.005- 10.002", testData))
+            Assert.assertEquals(20.0003F, instance.getResult("30.0005- 10.0002", testData))
+            Assert.assertEquals(20.00003F, instance.getResult("30.00005- 10.00002", testData))
+            Assert.assertEquals(20.000003F, instance.getResult("30.000005- 10.000002", testData))
+            Assert.assertEquals(20.0000003F, instance.getResult("30.0000005- 10.0000002", testData))
+            Assert.assertEquals(20.00000003F, instance.getResult("30.00000005- 10.00000002", testData))
+            Assert.assertEquals(20.000000003F, instance.getResult("30.000000005- 10.000000002", testData))
+            Assert.assertEquals(20.0000000003F, instance.getResult("30.0000000005- 10.0000000002", testData))
+            Assert.assertEquals(20.00000000003F, instance.getResult("30.00000000005- 10.00000000002", testData))
+            Assert.assertEquals(20.000000000003F, instance.getResult("30.000000000005- 10.000000000002", testData))
+            Assert.assertEquals("20.3", instance.getResult("30.5- 10.2 + ''", testData))
+            Assert.assertEquals("20.03", instance.getResult("30.05- 10.02  + ''", testData))
+            Assert.assertEquals("20.003", instance.getResult("30.005- 10.002  + ''", testData))
+            Assert.assertEquals("20.0003", instance.getResult("30.0005- 10.0002  + ''", testData))
+            Assert.assertEquals("20.00003", instance.getResult("30.00005- 10.00002  + ''", testData))
+            Assert.assertEquals("20.000003", instance.getResult("30.000005- 10.000002  + ''", testData))
+            Assert.assertEquals("20.0000003", instance.getResult("30.0000005- 10.0000002  + ''", testData))
+            Assert.assertEquals("20.00000003", instance.getResult("30.00000005- 10.00000002  + ''", testData))
+            Assert.assertEquals("20.000000003", instance.getResult("30.000000005- 10.000000002  + ''", testData))
+            Assert.assertEquals("20.0000000003", instance.getResult("30.0000000005- 10.0000000002  + ''", testData))
+            Assert.assertEquals("20.00000000003", instance.getResult("30.00000000005- 10.00000000002  + ''", testData))
+            Assert.assertEquals("20.000000000003", instance.getResult("30.000000000005- 10.000000000002  + ''", testData))
+            //乘法
+            Assert.assertEquals(40.3F, instance.getResult("40.3* 1.0", testData))
+            Assert.assertEquals(40.03F, instance.getResult("40.03* 1.00", testData))
+            Assert.assertEquals(40.003F, instance.getResult("40.003* 1.000", testData))
+            Assert.assertEquals(40.0003F, instance.getResult("40.0003* 1.0000", testData))
+            Assert.assertEquals(40.00003F, instance.getResult("40.00003* 1.00000", testData))
+            Assert.assertEquals(40.000003F, instance.getResult("40.000003* 1.000000", testData))
+            Assert.assertEquals(40.0000003F, instance.getResult("40.0000003* 1.0000000", testData))
+            Assert.assertEquals(40.00000003F, instance.getResult("40.00000003* 1.00000000", testData))
+            Assert.assertEquals(40.000000003F, instance.getResult("40.000000003* 1.000000000", testData))
+            Assert.assertEquals(40.0000000003F, instance.getResult("40.0000000003* 1.0000000000", testData))
+            Assert.assertEquals(40.00000000003F, instance.getResult("40.00000000003* 1.00000000000", testData))
+            Assert.assertEquals(40.000000000003F, instance.getResult("40.000000000003* 1.000000000000", testData))
+            Assert.assertEquals("40.3", instance.getResult("40.3* 1.0 + ''", testData))
+            Assert.assertEquals("40.03", instance.getResult("40.03* 1.00  + ''", testData))
+            Assert.assertEquals("40.003", instance.getResult("40.003* 1.000  + ''", testData))
+            Assert.assertEquals("40.0003", instance.getResult("40.0003* 1.0000  + ''", testData))
+            Assert.assertEquals("40.00003", instance.getResult("40.00003* 1.00000  + ''", testData))
+            Assert.assertEquals("40.000003", instance.getResult("40.000003* 1.000000  + ''", testData))
+            Assert.assertEquals("40.0000003", instance.getResult("40.0000003* 1.0000000  + ''", testData))
+            Assert.assertEquals("40.00000003", instance.getResult("40.00000003* 1.00000000  + ''", testData))
+            Assert.assertEquals("40.000000003", instance.getResult("40.000000003* 1.000000000  + ''", testData))
+            Assert.assertEquals("40.0000000003", instance.getResult("40.0000000003* 1.0000000000  + ''", testData))
+            Assert.assertEquals("40.00000000003", instance.getResult("40.00000000003* 1.00000000000  + ''", testData))
+            Assert.assertEquals("40.000000000003", instance.getResult("40.000000000003* 1.000000000000  + ''", testData))
+
+            Assert.assertEquals(20.3F, instance.getResult("20.3/ 1.0", testData))
+            Assert.assertEquals(20.03F, instance.getResult("20.03/ 1.00", testData))
+            Assert.assertEquals(20.003F, instance.getResult("20.003/ 1.000", testData))
+            Assert.assertEquals(20.0003F, instance.getResult("20.0003/ 1.0000", testData))
+            Assert.assertEquals(20.00003F, instance.getResult("20.00003/ 1.00000", testData))
+            Assert.assertEquals(20.000003F, instance.getResult("20.000003/ 1.000000", testData))
+            Assert.assertEquals(20.0000003F, instance.getResult("20.0000003/ 1.0000000", testData))
+            Assert.assertEquals(20.00000003F, instance.getResult("20.00000003/ 1.00000000", testData))
+            Assert.assertEquals(20.000000003F, instance.getResult("20.000000003/ 1.000000000", testData))
+            Assert.assertEquals(20.0000000003F, instance.getResult("20.0000000003/ 1.0000000000", testData))
+            Assert.assertEquals(20.00000000003F, instance.getResult("20.00000000003/ 1.00000000000", testData))
+            Assert.assertEquals(20.000000000003F, instance.getResult("20.000000000003/ 1.000000000000", testData))
+            Assert.assertEquals("20.3", instance.getResult("20.3/ 1.0 + ''", testData))
+            Assert.assertEquals("20.03", instance.getResult("20.03/ 1.00  + ''", testData))
+            Assert.assertEquals("20.003", instance.getResult("20.003/ 1.000  + ''", testData))
+            Assert.assertEquals("20.0003", instance.getResult("20.0003/ 1.0000  + ''", testData))
+            Assert.assertEquals("20.00003", instance.getResult("20.00003/ 1.00000  + ''", testData))
+            Assert.assertEquals("20.000003", instance.getResult("20.000003/ 1.000000  + ''", testData))
+            Assert.assertEquals("20.0000003", instance.getResult("20.0000003/ 1.0000000  + ''", testData))
+            Assert.assertEquals("20.00000003", instance.getResult("20.00000003/ 1.00000000  + ''", testData))
+            Assert.assertEquals("20.000000003", instance.getResult("20.000000003/ 1.000000000  + ''", testData))
+            Assert.assertEquals("20.0000000003", instance.getResult("20.0000000003/ 1.0000000000  + ''", testData))
+            Assert.assertEquals("20.00000000003", instance.getResult("20.00000000003/ 1.00000000000  + ''", testData))
+            Assert.assertEquals("20.000000000003", instance.getResult("20.000000000003/ 1.000000000000  + ''", testData))
+            //除法运算 保留小数测试
+            Assert.assertEquals(5.084746F, instance.getResult("12.000000/ 2.36", testData))
+            Assert.assertEquals("5.084746", instance.getResult("12.000000/ 2.36 + ''", testData))
+            Assert.assertEquals(5.0847458F, instance.getResult("12.0000000/ 2.36", testData))
+            Assert.assertEquals("5.0847458", instance.getResult("12.0000000/ 2.36 + ''", testData))
+            Assert.assertEquals(5.08475F, instance.getResult("12.00000/ 2.36", testData))
+            Assert.assertEquals("5.08475", instance.getResult("12.00000/ 2.36 + ''", testData))
+            Assert.assertEquals("5.084746", instance.getResult("12.000000/ 2.36  + ''", testData))
+
+            //取模运算
+            Assert.assertEquals(2.3F, instance.getResult("62.3% 60.0", testData))
+            Assert.assertEquals(2.03F, instance.getResult("62.03% 60.00", testData))
+            Assert.assertEquals(2.003F, instance.getResult("62.003% 60.000", testData))
+            Assert.assertEquals(2.0003F, instance.getResult("62.0003% 60.0000", testData))
+            Assert.assertEquals(2.00003F, instance.getResult("62.00003% 60.00000", testData))
+            Assert.assertEquals(2.000003F, instance.getResult("62.000003% 60.000000", testData))
+            Assert.assertEquals(2.0000003F, instance.getResult("62.0000003% 60.0000000", testData))
+            Assert.assertEquals(2.00000003F, instance.getResult("62.00000003% 60.00000000", testData))
+            Assert.assertEquals(2.000000003F, instance.getResult("62.000000003% 60.000000000", testData))
+            Assert.assertEquals(2.0000000003F, instance.getResult("62.0000000003% 60.0000000000", testData))
+            Assert.assertEquals(2.00000000003F, instance.getResult("62.00000000003% 60.00000000000", testData))
+            Assert.assertEquals(2.000000000003F, instance.getResult("62.000000000003% 60.000000000000", testData))
+            Assert.assertEquals("2.3", instance.getResult("62.3% 60.0 + ''", testData))
+            Assert.assertEquals("2.03", instance.getResult("62.03% 60.00  + ''", testData))
+            Assert.assertEquals("2.003", instance.getResult("62.003% 60.000  + ''", testData))
+            Assert.assertEquals("2.0003", instance.getResult("62.0003% 60.0000  + ''", testData))
+            Assert.assertEquals("2.00003", instance.getResult("62.00003% 60.00000  + ''", testData))
+            Assert.assertEquals("2.000003", instance.getResult("62.000003% 60.000000  + ''", testData))
+            Assert.assertEquals("2.0000003", instance.getResult("62.0000003% 60.0000000  + ''", testData))
+            Assert.assertEquals("2.00000003", instance.getResult("62.00000003% 60.00000000  + ''", testData))
+            Assert.assertEquals("2.000000003", instance.getResult("62.000000003% 60.000000000  + ''", testData))
+            Assert.assertEquals("2.0000000003", instance.getResult("62.0000000003% 60.0000000000  + ''", testData))
+            Assert.assertEquals("2.00000000003", instance.getResult("62.00000000003% 60.00000000000  + ''", testData))
+            Assert.assertEquals("2.000000000003", instance.getResult("62.000000000003% 60.000000000000  + ''", testData))
+
+            Assert.assertEquals("22.32", instance.getResult("10.22+10+1.0+1.1 + ''", testData))
+            Assert.assertEquals("22.32", instance.getResult("10.22+10+1.0+1.1 + ''", testData))
+
+        }
+
     }
 
     @Test
@@ -325,15 +575,16 @@ class GXAnalyzeTest {
                 this["array"] = JSONArray()
             }
         }
-
-        Assert.assertEquals(-0.5f, instance.getResult("-1.0/2.0", testData))
-        Assert.assertEquals(0L, instance.getResult("-1/2", testData))
-        Assert.assertEquals(0.5f, instance.getResult("1.0/2", testData))
-        Assert.assertEquals(0L, instance.getResult("1/2", testData))
-        Assert.assertEquals(1L, instance.getResult("1/1", testData))
-        Assert.assertEquals(1L, instance.getResult("-1/-1", testData))
-        Assert.assertEquals(-8f, instance.getResult("\$eight/-1", testData))
-        Assert.assertEquals(1f, instance.getResult("\$eight/\$eight", testData))
+        repeat(10) {
+            Assert.assertEquals(-0.5f, instance.getResult("-1.0/2.0", testData))
+            Assert.assertEquals(0L, instance.getResult("-1/2", testData))
+            Assert.assertEquals(0.5f, instance.getResult("1.0/2", testData))
+            Assert.assertEquals(0L, instance.getResult("1/2", testData))
+            Assert.assertEquals(1L, instance.getResult("1/1", testData))
+            Assert.assertEquals(1L, instance.getResult("-1/-1", testData))
+            Assert.assertEquals(-8f, instance.getResult("\$eight/-1", testData))
+            Assert.assertEquals(1f, instance.getResult("\$eight/\$eight", testData))
+        }
     }
 
     @Test
@@ -346,15 +597,16 @@ class GXAnalyzeTest {
                 this["array"] = JSONArray()
             }
         }
-
-        Assert.assertEquals(8L, instance.getResult("1+1*2+3+4/2", testData))
-        Assert.assertEquals(-1L, instance.getResult("(1+1-3)", testData))
-        Assert.assertEquals(-2L, instance.getResult("(1+1)-2*2", testData))
-        Assert.assertEquals(-4L, instance.getResult("(1-3)*2", testData))
-        Assert.assertEquals(4L, instance.getResult("1+1*3", testData))
-        Assert.assertEquals(4L, instance.getResult("1+2*3/2", testData))
-        Assert.assertEquals(4L, instance.getResult("(1+1)*2", testData))
-        Assert.assertEquals(2L, instance.getResult("(1+3)/2", testData))
+        repeat(10) {
+            Assert.assertEquals(8L, instance.getResult("1+1*2+3+4/2", testData))
+            Assert.assertEquals(-1L, instance.getResult("(1+1-3)", testData))
+            Assert.assertEquals(-2L, instance.getResult("(1+1)-2*2", testData))
+            Assert.assertEquals(-4L, instance.getResult("(1-3)*2", testData))
+            Assert.assertEquals(4L, instance.getResult("1+1*3", testData))
+            Assert.assertEquals(4L, instance.getResult("1+2*3/2", testData))
+            Assert.assertEquals(4L, instance.getResult("(1+1)*2", testData))
+            Assert.assertEquals(2L, instance.getResult("(1+3)/2", testData))
+        }
     }
 
     @Test
@@ -367,11 +619,12 @@ class GXAnalyzeTest {
                 this["array"] = JSONArray()
             }
         }
-
-        Assert.assertEquals(1L, instance.getResult("+1", testData))
-        Assert.assertEquals(-1L, instance.getResult("-1", testData))
-        Assert.assertEquals(true, instance.getResult("!false", testData))
-        Assert.assertEquals(false, instance.getResult("!true", testData))
+        repeat(10) {
+            Assert.assertEquals(1L, instance.getResult("+1", testData))
+            Assert.assertEquals(-1L, instance.getResult("-1", testData))
+            Assert.assertEquals(true, instance.getResult("!false", testData))
+            Assert.assertEquals(false, instance.getResult("!true", testData))
+        }
     }
 
     @Test
@@ -384,14 +637,15 @@ class GXAnalyzeTest {
                 this["array"] = JSONArray()
             }
         }
-
-        Assert.assertEquals(false, instance.getResult("null != null", testData))
-        Assert.assertEquals(true, instance.getResult("1 != null", testData))
-        Assert.assertEquals(true, instance.getResult("'string'!='s2tring'", testData))
-        Assert.assertEquals(false, instance.getResult("1 != 1.0", testData))
-        Assert.assertEquals(true, instance.getResult("1!=1.1", testData))
-        Assert.assertEquals(true, instance.getResult("true != 'false'", testData))
-        Assert.assertEquals(false, instance.getResult("true != 'true'", testData))
+        repeat(10) {
+            Assert.assertEquals(false, instance.getResult("null != null", testData))
+            Assert.assertEquals(true, instance.getResult("1 != null", testData))
+            Assert.assertEquals(true, instance.getResult("'string'!='s2tring'", testData))
+            Assert.assertEquals(false, instance.getResult("1 != 1.0", testData))
+            Assert.assertEquals(true, instance.getResult("1!=1.1", testData))
+            Assert.assertEquals(true, instance.getResult("true != 'false'", testData))
+            Assert.assertEquals(false, instance.getResult("true != 'true'", testData))
+        }
     }
 
     @Test
@@ -404,18 +658,19 @@ class GXAnalyzeTest {
                 this["array"] = JSONArray()
             }
         }
-
-        Assert.assertEquals(false, instance.getResult("true == false", testData))
-        Assert.assertEquals(true, instance.getResult("null == null", testData))
-        Assert.assertEquals(true, instance.getResult("\$eight == 8", testData))
-        Assert.assertEquals(false, instance.getResult("1==2", testData))
-        Assert.assertEquals(true, instance.getResult("1==1.0", testData))
-        Assert.assertEquals(false, instance.getResult("'string'==1.0", testData))
-        Assert.assertEquals(true, instance.getResult("'string'=='string'", testData))
-        Assert.assertEquals(true, instance.getResult("1+1 == 2", testData))
-        Assert.assertEquals(true, instance.getResult("true == 'true'", testData))
-        Assert.assertEquals(false, instance.getResult("3 == 2", testData))
-        Assert.assertEquals(false, instance.getResult("'string' == 2", testData))
+        repeat(10) {
+            Assert.assertEquals(false, instance.getResult("true == false", testData))
+            Assert.assertEquals(true, instance.getResult("null == null", testData))
+            Assert.assertEquals(true, instance.getResult("\$eight == 8", testData))
+            Assert.assertEquals(false, instance.getResult("1==2", testData))
+            Assert.assertEquals(true, instance.getResult("1==1.0", testData))
+            Assert.assertEquals(false, instance.getResult("'string'==1.0", testData))
+            Assert.assertEquals(true, instance.getResult("'string'=='string'", testData))
+            Assert.assertEquals(true, instance.getResult("1+1 == 2", testData))
+            Assert.assertEquals(true, instance.getResult("true == 'true'", testData))
+            Assert.assertEquals(false, instance.getResult("3 == 2", testData))
+            Assert.assertEquals(false, instance.getResult("'string' == 2", testData))
+        }
     }
 
 
@@ -429,12 +684,13 @@ class GXAnalyzeTest {
                 this["array"] = JSONArray()
             }
         }
-
-        Assert.assertEquals(true, instance.getResult("3 > 2", testData))
-        Assert.assertEquals(false, instance.getResult("'string' > 2", testData))
-        Assert.assertEquals(false, instance.getResult("1+1 > 2", testData))
-        Assert.assertEquals(true, instance.getResult("1+1 >= 2", testData))
-        Assert.assertEquals(false, instance.getResult("'string' >= 2", testData))
+        repeat(10) {
+            Assert.assertEquals(true, instance.getResult("3 > 2", testData))
+            Assert.assertEquals(false, instance.getResult("'string' > 2", testData))
+            Assert.assertEquals(false, instance.getResult("1+1 > 2", testData))
+            Assert.assertEquals(true, instance.getResult("1+1 >= 2", testData))
+            Assert.assertEquals(false, instance.getResult("'string' >= 2", testData))
+        }
     }
 
     @Test
@@ -447,12 +703,13 @@ class GXAnalyzeTest {
                 this["array"] = JSONArray()
             }
         }
-
-        Assert.assertEquals(false, instance.getResult("'string' < 2", testData))
-        Assert.assertEquals(false, instance.getResult("3 < 2", testData))
-        Assert.assertEquals(true, instance.getResult("2 < 3", testData))
-        Assert.assertEquals(false, instance.getResult("'string' <= 2", testData))
-        Assert.assertEquals(false, instance.getResult("1+1 < 2", testData))
+        repeat(10) {
+            Assert.assertEquals(false, instance.getResult("'string' < 2", testData))
+            Assert.assertEquals(false, instance.getResult("3 < 2", testData))
+            Assert.assertEquals(true, instance.getResult("2 < 3", testData))
+            Assert.assertEquals(false, instance.getResult("'string' <= 2", testData))
+            Assert.assertEquals(false, instance.getResult("1+1 < 2", testData))
+        }
     }
 
     @Test
@@ -465,10 +722,11 @@ class GXAnalyzeTest {
                 this["array"] = JSONArray()
             }
         }
-
-        Assert.assertEquals(true, instance.getResult("true || true", testData))
-        Assert.assertEquals(false, instance.getResult("false || false", testData))
-        Assert.assertEquals(true, instance.getResult("true || false", testData))
+        repeat(10) {
+            Assert.assertEquals(true, instance.getResult("true || true", testData))
+            Assert.assertEquals(false, instance.getResult("false || false", testData))
+            Assert.assertEquals(true, instance.getResult("true || false", testData))
+        }
     }
 
     @Test
@@ -481,10 +739,11 @@ class GXAnalyzeTest {
                 this["array"] = JSONArray()
             }
         }
-
-        Assert.assertEquals(false, instance.getResult("true && false", testData))
-        Assert.assertEquals(true, instance.getResult("true && true", testData))
-        Assert.assertEquals(false, instance.getResult("false && false", testData))
+        repeat(10) {
+            Assert.assertEquals(false, instance.getResult("true && false", testData))
+            Assert.assertEquals(true, instance.getResult("true && true", testData))
+            Assert.assertEquals(false, instance.getResult("false && false", testData))
+        }
     }
 
     @Test
@@ -497,23 +756,28 @@ class GXAnalyzeTest {
                 this["array"] = JSONArray()
             }
         }
-        Assert.assertEquals("flex", instance.getResult("\$data.map ? 'flex' : 'none'", testData))
-        Assert.assertEquals("none", instance.getResult("\$data.map ? 'flex' : 'none'", null))
-        Assert.assertEquals(null, instance.getResult("false ? \$data : null", testData))
-        Assert.assertEquals(0L, instance.getResult("false ? 1 : 0", testData))
-        Assert.assertEquals(1L, instance.getResult("true ? 1 : 0", testData))
-        Assert.assertEquals(1L, instance.getResult("true ? 1 : 0", testData))
-        Assert.assertEquals(true, instance.getResult("true ?: 1", testData))
-        Assert.assertEquals(1L, instance.getResult("false ?: 1", testData))
-        Assert.assertEquals(true, instance.getResult("true ?: \$data", testData))
-        Assert.assertEquals("123", instance.getResult("true ? '123' : '456'", testData))
-        Assert.assertEquals("123", instance.getResult("'true' ? '123' : '456'", testData))
-        Assert.assertEquals(null, instance.getResult("true ? null : \$data", testData))
-        Assert.assertEquals(1L, instance.getResult("false ? \$\$ : 1", testData))
-        Assert.assertEquals(testData, instance.getResult("true ? \$\$ : 1", testData))
-        Assert.assertEquals(testData, instance.getResult("\$\$ ?: 0", testData))
-        Assert.assertEquals(2L, instance.getResult("\$data.true?1:2", testData))
-        Assert.assertEquals(2L, instance.getResult("\$data.false?1:2", testData))
+        repeat(10) {
+            Assert.assertEquals(
+                "flex",
+                instance.getResult("\$data.map ? 'flex' : 'none'", testData)
+            )
+            Assert.assertEquals("none", instance.getResult("\$data.map ? 'flex' : 'none'", null))
+            Assert.assertEquals(null, instance.getResult("false ? \$data : null", testData))
+            Assert.assertEquals(0L, instance.getResult("false ? 1 : 0", testData))
+            Assert.assertEquals(1L, instance.getResult("true ? 1 : 0", testData))
+            Assert.assertEquals(1L, instance.getResult("true ? 1 : 0", testData))
+            Assert.assertEquals(true, instance.getResult("true ?: 1", testData))
+            Assert.assertEquals(1L, instance.getResult("false ?: 1", testData))
+            Assert.assertEquals(true, instance.getResult("true ?: \$data", testData))
+            Assert.assertEquals("123", instance.getResult("true ? '123' : '456'", testData))
+            Assert.assertEquals("123", instance.getResult("'true' ? '123' : '456'", testData))
+            Assert.assertEquals(null, instance.getResult("true ? null : \$data", testData))
+            Assert.assertEquals(1L, instance.getResult("false ? \$\$ : 1", testData))
+            Assert.assertEquals(testData, instance.getResult("true ? \$\$ : 1", testData))
+            Assert.assertEquals(testData, instance.getResult("\$\$ ?: 0", testData))
+            Assert.assertEquals(2L, instance.getResult("\$data.true?1:2", testData))
+            Assert.assertEquals(2L, instance.getResult("\$data.false?1:2", testData))
+        }
     }
 
     @Test

--- a/GaiaXAnalyze/GXAnalyzeCore/GXAnalyze.cpp
+++ b/GaiaXAnalyze/GXAnalyzeCore/GXAnalyze.cpp
@@ -463,11 +463,6 @@ GXATSNode GXAnalyze::doubleCalculate(GXATSNode left, GXATSNode right, string op)
                       left.token + "'";
         result.token = "error";
         return result;
-    } else if (op != "?:" && (right.token == "map" || right.token == "array")) {
-        result.name = "expressionError: illegal operator '" + op + "',right operand has type of '" +
-                      right.token + "'";
-        result.token = "error";
-        return result;
     }
     //返回值都为bool
     if (op == ">") {
@@ -721,7 +716,8 @@ GXATSNode GXAnalyze::doubleCalculate(GXATSNode left, GXATSNode right, string op)
         } else {
             result.name = "false";
         }
-    } else if (op == "?") {
+    }
+    else if (op == "?") {
         if (left.name == "true" || ((left.name != "false" && left.token != "null"))) {
             result.name = right.name;
             result.token = right.token;
@@ -732,7 +728,8 @@ GXATSNode GXAnalyze::doubleCalculate(GXATSNode left, GXATSNode right, string op)
             result.token = "right";
             result.name = "right";
         }
-    } else if (op == "?:") {
+    }
+    else if (op == "?:") {
         if (left.name == "true" || (left.name != "false" && left.token != "null")) {
             result.name = left.name;
             result.token = left.token;
@@ -740,7 +737,8 @@ GXATSNode GXAnalyze::doubleCalculate(GXATSNode left, GXATSNode right, string op)
             result.name = right.name;
             result.token = right.token;
         }
-    } else if (op == ":") {
+    }
+    else if (op == ":") {
         if (left.token == "right" && left.name == "right") {
             result.token = right.token;
             result.name = right.name;
@@ -748,7 +746,8 @@ GXATSNode GXAnalyze::doubleCalculate(GXATSNode left, GXATSNode right, string op)
             result.token = left.token;
             result.name = left.name;
         }
-    } else if (op == "+") {
+    }
+    else if (op == "+") {
         if ((left.token == "num" || left.token == "long") &&
             (right.token == "num" || right.token == "long")) {
             if (left.token == "num" || right.token == "num") {
@@ -768,21 +767,9 @@ GXATSNode GXAnalyze::doubleCalculate(GXATSNode left, GXATSNode right, string op)
             result.token = "null";
         } else {
             if ((left.token == "num" || left.token == "long") && right.token == "string") {
-//                if (left.name.find('.') != -1) {
-//                    regex e("0+?$");
-//                    regex e2("[.]$");
-//                    left.name = regex_replace(left.name, e, "");
-//                    left.name = regex_replace(left.name, e2, "");
-//                }
                 result.name = left.name + right.name;
                 result.token = "string";
             } else if ((right.token == "num" || right.token == "long") && left.token == "string") {
-//                if (right.name.find('.') != -1) {
-//                    regex e("0+?$");
-//                    regex e2("[.]$");
-//                    right.name = regex_replace(right.name, e, ""); // 除了捕捉到的组以外，其他的东西均舍弃
-//                    right.name = regex_replace(right.name, e2, ""); // 除了捕捉到的组以外，其他的东西均舍弃
-//                }
                 result.name = left.name + right.name;
                 result.token = "string";
             } else {
@@ -800,7 +787,8 @@ GXATSNode GXAnalyze::doubleCalculate(GXATSNode left, GXATSNode right, string op)
                 }
             }
         }
-    } else if (op == "-") {
+    }
+    else if (op == "-") {
         if ((left.token == "num" || left.token == "long") &&
             (right.token == "num" || right.token == "long")) {
 
@@ -835,7 +823,8 @@ GXATSNode GXAnalyze::doubleCalculate(GXATSNode left, GXATSNode right, string op)
                         left.token;
             }
         }
-    } else if (op == "*") {
+    }
+    else if (op == "*") {
         if ((left.token == "num" || left.token == "long") &&
             (right.token == "num" || right.token == "long")) {
             if (left.token == "num" || right.token == "num") {
@@ -869,7 +858,8 @@ GXATSNode GXAnalyze::doubleCalculate(GXATSNode left, GXATSNode right, string op)
                         left.token;
             }
         }
-    } else if (op == "/") {
+    }
+    else if (op == "/") {
         if ((left.token == "num" || left.token == "long") &&
             (right.token == "num" || right.token == "long")) {
             if (stof(right.name) == 0) {
@@ -914,7 +904,8 @@ GXATSNode GXAnalyze::doubleCalculate(GXATSNode left, GXATSNode right, string op)
                         left.token;
             }
         }
-    } else if (op == "%") {
+    }
+    else if (op == "%") {
         if ((left.token == "num" || left.token == "long") &&
             (right.token == "num" || right.token == "long")) {
             if (stof(right.name) == 0) {
@@ -947,6 +938,10 @@ GXATSNode GXAnalyze::doubleCalculate(GXATSNode left, GXATSNode right, string op)
                         left.token;
             }
         }
+    }
+    else{
+        result.token = "error";
+        result.name = "expressionError: wrong expression";
     }
     return result;
 }
@@ -1068,6 +1063,9 @@ long GXAnalyze::getValue(string expression, void *source) {
                     } else if (gxv->tag == GX_TAG_NULL) {
                         tokenNum.name = "null";
                         tokenNum.token = "null";
+                    }else{
+                        tokenNum.name = "null";
+                        tokenNum.token = "null";
                     }
                     if (gxv->tag == GX_TAG_STRING && gxv->str != NULL) {
                         delete[] gxv->str;
@@ -1113,6 +1111,9 @@ long GXAnalyze::getValue(string expression, void *source) {
                     } else if (gxv->tag == GX_TAG_NULL) {
                         tokenNum.name = "null";
                         tokenNum.token = "null";
+                    }else{
+                        tokenNum.name = "null";
+                        tokenNum.token = "null";
                     }
                     if (gxv->tag == GX_TAG_STRING && gxv->str != NULL) {
                         delete[] gxv->str;
@@ -1152,12 +1153,6 @@ long GXAnalyze::getValue(string expression, void *source) {
                     pointer = new GXValue(GX_TAG_BOOL, 0);
                 }
             } else if (res.token == "num") {
-//                if (res.name.find('.') != -1) {
-//                    regex e("0+?$");
-//                    regex e2("[.]$");
-//                    res.name = regex_replace(res.name, e, "");
-//                    res.name = regex_replace(res.name, e2, "");
-//                }
                 pointer = new GXValue(GX_TAG_FLOAT, (float) atof(res.name.c_str()));
             } else if (res.token == "long") {
                 pointer = new GXValue(GX_TAG_LONG, (int64_t) atoll(res.name.c_str()));
@@ -1166,6 +1161,8 @@ long GXAnalyze::getValue(string expression, void *source) {
             } else if (res.token == "array") {
                 pointer = new GXValue(GX_TAG_ARRAY, (void *) atol(res.name.c_str()));
             } else if (res.token == "null") {
+                pointer = new GXValue(GX_TAG_NULL, 1);
+            }else{
                 pointer = new GXValue(GX_TAG_NULL, 1);
             }
             Res = (long) pointer;
@@ -1271,6 +1268,9 @@ GXAnalyze::calculateCache(string cacheString, vector<GXATSNode> array, void *p_a
                 } else if (node.token == "null") {
                     GXValue *par = new GXValue(GX_TAG_NULL, 1);
                     paramsTempArray.push_back((long) par);
+                }else{
+                    GXValue *par = new GXValue(GX_TAG_NULL, 1);
+                    paramsTempArray.push_back((long) par);
                 }
                 num1 = -1;
             } else if (cacheString[i] == 'g') {
@@ -1311,6 +1311,9 @@ GXAnalyze::calculateCache(string cacheString, vector<GXATSNode> array, void *p_a
                                 node.name.c_str()));
                         paramsTempArray.push_back((long) par);
                     } else if (node.token == "null") {
+                        GXValue *par = new GXValue(GX_TAG_NULL, 1);
+                        paramsTempArray.push_back((long) par);
+                    }else{
                         GXValue *par = new GXValue(GX_TAG_NULL, 1);
                         paramsTempArray.push_back((long) par);
                     }
@@ -1380,6 +1383,9 @@ GXAnalyze::calculateCache(string cacheString, vector<GXATSNode> array, void *p_a
                     } else if (fun->tag == GX_TAG_NULL) {
                         node.name = "null";
                         node.token = "null";
+                    }else{
+                        node.name = "null";
+                        node.token = "null";
                     }
                     array[numFunction] = node;
                     res = array[numFunction];
@@ -1417,12 +1423,6 @@ GXAnalyze::calculateCache(string cacheString, vector<GXATSNode> array, void *p_a
             pointer = new GXValue(GX_TAG_BOOL, 0);
         }
     } else if (res.token == "num") {
-//        if (res.name.find('.') != -1) {
-//            regex e("0+?$");
-//            regex e2("[.]$");
-//            res.name = regex_replace(res.name, e, "");
-//            res.name = regex_replace(res.name, e2, "");
-//        }
         pointer = new GXValue(GX_TAG_FLOAT, (float) atof(res.name.c_str()));
     } else if (res.token == "long") {
         pointer = new GXValue(GX_TAG_LONG, (int64_t) atoll(res.name.c_str()));
@@ -1431,6 +1431,8 @@ GXAnalyze::calculateCache(string cacheString, vector<GXATSNode> array, void *p_a
     } else if (res.token == "array") {
         pointer = new GXValue(GX_TAG_ARRAY, (void *) atol(res.name.c_str()));
     } else if (res.token == "null") {
+        pointer = new GXValue(GX_TAG_NULL, 1);
+    }else{
         pointer = new GXValue(GX_TAG_NULL, 1);
     }
 
@@ -1486,12 +1488,6 @@ long GXAnalyze::check(string s, vector<GXATSNode> array, void *p_analyze, void *
                     pointer = new GXValue(GX_TAG_BOOL, 0);
                 }
             } else if (valueStack[0].token == "num") {
-//                if (valueStack[0].name.find('.') != -1) {
-//                    regex e("0+?$");
-//                    regex e2("[.]$");
-//                    valueStack[0].name = regex_replace(valueStack[0].name, e, "");
-//                    valueStack[0].name = regex_replace(valueStack[0].name, e2, "");
-//                }
                 pointer = new GXValue(GX_TAG_FLOAT, (float) atof(valueStack[0].name.c_str()));
             } else if (valueStack[0].token == "long") {
                 pointer = new GXValue(GX_TAG_LONG, (int64_t) atoll(valueStack[0].name.c_str()));
@@ -1500,6 +1496,8 @@ long GXAnalyze::check(string s, vector<GXATSNode> array, void *p_analyze, void *
             } else if (valueStack[0].token == "array") {
                 pointer = new GXValue(GX_TAG_ARRAY, (void *) atol(valueStack[0].name.c_str()));
             } else if (valueStack[0].token == "null") {
+                pointer = new GXValue(GX_TAG_NULL, 1);
+            }else{
                 pointer = new GXValue(GX_TAG_NULL, 1);
             }
             delete[] statusStack;
@@ -1578,6 +1576,9 @@ long GXAnalyze::check(string s, vector<GXATSNode> array, void *p_analyze, void *
                         } else if (gxv->tag == GX_TAG_NULL) {
                             t1.name = "null";
                             t1.token = "null";
+                        }else{
+                            t1.name = "null";
+                            t1.token = "null";
                         }
                         valueStack[valueSize] = t1;
                         ++valueSize;
@@ -1627,6 +1628,9 @@ long GXAnalyze::check(string s, vector<GXATSNode> array, void *p_analyze, void *
                             t1.name = to_string((long) (gxv->ptr));
                             t1.token = "map";
                         } else if (gxv->tag == GX_TAG_NULL) {
+                            t1.name = "null";
+                            t1.token = "null";
+                        }else{
                             t1.name = "null";
                             t1.token = "null";
                         }
@@ -1784,6 +1788,9 @@ long GXAnalyze::check(string s, vector<GXATSNode> array, void *p_analyze, void *
                                         } else if (fun->tag == GX_TAG_NULL) {
                                             tempR.name = "null";
                                             tempR.token = "null";
+                                        }else{
+                                            tempR.name = "null";
+                                            tempR.token = "null";
                                         }
                                         --valueSize;
                                         isFunction = false;
@@ -1831,6 +1838,9 @@ long GXAnalyze::check(string s, vector<GXATSNode> array, void *p_analyze, void *
                                                     valueStack[i].name.c_str()));
                                             paramsTempArray.push_back((long) par);
                                         } else if (valueStack[i].token == "null") {
+                                            GXValue *par = new GXValue(GX_TAG_NULL, 1);
+                                            paramsTempArray.push_back((long) par);
+                                        }else{
                                             GXValue *par = new GXValue(GX_TAG_NULL, 1);
                                             paramsTempArray.push_back((long) par);
                                         }

--- a/GaiaXAnalyze/GXAnalyzeCore/GXAnalyze.cpp
+++ b/GaiaXAnalyze/GXAnalyzeCore/GXAnalyze.cpp
@@ -716,8 +716,7 @@ GXATSNode GXAnalyze::doubleCalculate(GXATSNode left, GXATSNode right, string op)
         } else {
             result.name = "false";
         }
-    }
-    else if (op == "?") {
+    } else if (op == "?") {
         if (left.name == "true" || ((left.name != "false" && left.token != "null"))) {
             result.name = right.name;
             result.token = right.token;
@@ -728,8 +727,7 @@ GXATSNode GXAnalyze::doubleCalculate(GXATSNode left, GXATSNode right, string op)
             result.token = "right";
             result.name = "right";
         }
-    }
-    else if (op == "?:") {
+    } else if (op == "?:") {
         if (left.name == "true" || (left.name != "false" && left.token != "null")) {
             result.name = left.name;
             result.token = left.token;
@@ -737,8 +735,7 @@ GXATSNode GXAnalyze::doubleCalculate(GXATSNode left, GXATSNode right, string op)
             result.name = right.name;
             result.token = right.token;
         }
-    }
-    else if (op == ":") {
+    } else if (op == ":") {
         if (left.token == "right" && left.name == "right") {
             result.token = right.token;
             result.name = right.name;
@@ -746,15 +743,14 @@ GXATSNode GXAnalyze::doubleCalculate(GXATSNode left, GXATSNode right, string op)
             result.token = left.token;
             result.name = left.name;
         }
-    }
-    else if (op == "+") {
+    } else if (op == "+") {
         if ((left.token == "num" || left.token == "long") &&
             (right.token == "num" || right.token == "long")) {
             if (left.token == "num" || right.token == "num") {
                 float temp = stof(left.name) + stof(right.name);
                 result.name = to_string(temp);
                 result.token = "num";
-            }else{
+            } else {
                 long temp = stol(left.name) + stol(right.name);
                 result.name = to_string(temp);
                 result.token = "long";
@@ -787,8 +783,7 @@ GXATSNode GXAnalyze::doubleCalculate(GXATSNode left, GXATSNode right, string op)
                 }
             }
         }
-    }
-    else if (op == "-") {
+    } else if (op == "-") {
         if ((left.token == "num" || left.token == "long") &&
             (right.token == "num" || right.token == "long")) {
 
@@ -796,7 +791,7 @@ GXATSNode GXAnalyze::doubleCalculate(GXATSNode left, GXATSNode right, string op)
                 float temp = stof(left.name) - stof(right.name);
                 result.name = to_string(temp);
                 result.token = "num";
-            }else{
+            } else {
                 long temp = stol(left.name) - stol(right.name);
                 result.name = to_string(temp);
                 result.token = "long";
@@ -823,15 +818,14 @@ GXATSNode GXAnalyze::doubleCalculate(GXATSNode left, GXATSNode right, string op)
                         left.token;
             }
         }
-    }
-    else if (op == "*") {
+    } else if (op == "*") {
         if ((left.token == "num" || left.token == "long") &&
             (right.token == "num" || right.token == "long")) {
             if (left.token == "num" || right.token == "num") {
                 float temp = stof(left.name) * stof(right.name);
                 result.name = to_string(temp);
                 result.token = "num";
-            }else{
+            } else {
                 long temp = stol(left.name) * stol(right.name);
                 result.name = to_string(temp);
                 result.token = "long";
@@ -858,8 +852,7 @@ GXATSNode GXAnalyze::doubleCalculate(GXATSNode left, GXATSNode right, string op)
                         left.token;
             }
         }
-    }
-    else if (op == "/") {
+    } else if (op == "/") {
         if ((left.token == "num" || left.token == "long") &&
             (right.token == "num" || right.token == "long")) {
             if (stof(right.name) == 0) {
@@ -870,13 +863,13 @@ GXATSNode GXAnalyze::doubleCalculate(GXATSNode left, GXATSNode right, string op)
                     float temp = stof(left.name) / stof(right.name);
                     result.name = to_string(temp);
                     result.token = "num";
-                }else{
+                } else {
                     long temp = stol(left.name) / stol(right.name);
                     long double tempF = stold(left.name) / stold(right.name);
-                    if(temp != tempF && (left.token == "num" || right.token == "num")){
+                    if (temp != tempF && (left.token == "num" || right.token == "num")) {
                         result.name = to_string(tempF);
                         result.token = "num";
-                    }else{
+                    } else {
                         result.name = to_string(temp);
                         result.token = "long";
                     }
@@ -904,8 +897,7 @@ GXATSNode GXAnalyze::doubleCalculate(GXATSNode left, GXATSNode right, string op)
                         left.token;
             }
         }
-    }
-    else if (op == "%") {
+    } else if (op == "%") {
         if ((left.token == "num" || left.token == "long") &&
             (right.token == "num" || right.token == "long")) {
             if (stof(right.name) == 0) {
@@ -938,8 +930,7 @@ GXATSNode GXAnalyze::doubleCalculate(GXATSNode left, GXATSNode right, string op)
                         left.token;
             }
         }
-    }
-    else{
+    } else {
         result.token = "error";
         result.name = "expressionError: wrong expression";
     }
@@ -1063,7 +1054,7 @@ long GXAnalyze::getValue(string expression, void *source) {
                     } else if (gxv->tag == GX_TAG_NULL) {
                         tokenNum.name = "null";
                         tokenNum.token = "null";
-                    }else{
+                    } else {
                         tokenNum.name = "null";
                         tokenNum.token = "null";
                     }
@@ -1111,7 +1102,7 @@ long GXAnalyze::getValue(string expression, void *source) {
                     } else if (gxv->tag == GX_TAG_NULL) {
                         tokenNum.name = "null";
                         tokenNum.token = "null";
-                    }else{
+                    } else {
                         tokenNum.name = "null";
                         tokenNum.token = "null";
                     }
@@ -1162,7 +1153,7 @@ long GXAnalyze::getValue(string expression, void *source) {
                 pointer = new GXValue(GX_TAG_ARRAY, (void *) atol(res.name.c_str()));
             } else if (res.token == "null") {
                 pointer = new GXValue(GX_TAG_NULL, 1);
-            }else{
+            } else {
                 pointer = new GXValue(GX_TAG_NULL, 1);
             }
             Res = (long) pointer;
@@ -1268,7 +1259,7 @@ GXAnalyze::calculateCache(string cacheString, vector<GXATSNode> array, void *p_a
                 } else if (node.token == "null") {
                     GXValue *par = new GXValue(GX_TAG_NULL, 1);
                     paramsTempArray.push_back((long) par);
-                }else{
+                } else {
                     GXValue *par = new GXValue(GX_TAG_NULL, 1);
                     paramsTempArray.push_back((long) par);
                 }
@@ -1313,7 +1304,7 @@ GXAnalyze::calculateCache(string cacheString, vector<GXATSNode> array, void *p_a
                     } else if (node.token == "null") {
                         GXValue *par = new GXValue(GX_TAG_NULL, 1);
                         paramsTempArray.push_back((long) par);
-                    }else{
+                    } else {
                         GXValue *par = new GXValue(GX_TAG_NULL, 1);
                         paramsTempArray.push_back((long) par);
                     }
@@ -1383,7 +1374,7 @@ GXAnalyze::calculateCache(string cacheString, vector<GXATSNode> array, void *p_a
                     } else if (fun->tag == GX_TAG_NULL) {
                         node.name = "null";
                         node.token = "null";
-                    }else{
+                    } else {
                         node.name = "null";
                         node.token = "null";
                     }
@@ -1432,7 +1423,7 @@ GXAnalyze::calculateCache(string cacheString, vector<GXATSNode> array, void *p_a
         pointer = new GXValue(GX_TAG_ARRAY, (void *) atol(res.name.c_str()));
     } else if (res.token == "null") {
         pointer = new GXValue(GX_TAG_NULL, 1);
-    }else{
+    } else {
         pointer = new GXValue(GX_TAG_NULL, 1);
     }
 
@@ -1497,7 +1488,7 @@ long GXAnalyze::check(string s, vector<GXATSNode> array, void *p_analyze, void *
                 pointer = new GXValue(GX_TAG_ARRAY, (void *) atol(valueStack[0].name.c_str()));
             } else if (valueStack[0].token == "null") {
                 pointer = new GXValue(GX_TAG_NULL, 1);
-            }else{
+            } else {
                 pointer = new GXValue(GX_TAG_NULL, 1);
             }
             delete[] statusStack;
@@ -1576,7 +1567,7 @@ long GXAnalyze::check(string s, vector<GXATSNode> array, void *p_analyze, void *
                         } else if (gxv->tag == GX_TAG_NULL) {
                             t1.name = "null";
                             t1.token = "null";
-                        }else{
+                        } else {
                             t1.name = "null";
                             t1.token = "null";
                         }
@@ -1630,7 +1621,7 @@ long GXAnalyze::check(string s, vector<GXATSNode> array, void *p_analyze, void *
                         } else if (gxv->tag == GX_TAG_NULL) {
                             t1.name = "null";
                             t1.token = "null";
-                        }else{
+                        } else {
                             t1.name = "null";
                             t1.token = "null";
                         }
@@ -1788,7 +1779,7 @@ long GXAnalyze::check(string s, vector<GXATSNode> array, void *p_analyze, void *
                                         } else if (fun->tag == GX_TAG_NULL) {
                                             tempR.name = "null";
                                             tempR.token = "null";
-                                        }else{
+                                        } else {
                                             tempR.name = "null";
                                             tempR.token = "null";
                                         }
@@ -1840,7 +1831,7 @@ long GXAnalyze::check(string s, vector<GXATSNode> array, void *p_analyze, void *
                                         } else if (valueStack[i].token == "null") {
                                             GXValue *par = new GXValue(GX_TAG_NULL, 1);
                                             paramsTempArray.push_back((long) par);
-                                        }else{
+                                        } else {
                                             GXValue *par = new GXValue(GX_TAG_NULL, 1);
                                             paramsTempArray.push_back((long) par);
                                         }

--- a/GaiaXAnalyze/GXAnalyzeCore/GXAnalyze.cpp
+++ b/GaiaXAnalyze/GXAnalyzeCore/GXAnalyze.cpp
@@ -1,5 +1,8 @@
 #include "GXAnalyze.h"
 #include <mutex>          // std::mutex
+#include<cmath>   //c头文件
+#include <sstream>
+#include <iomanip>
 
 using namespace std;
 
@@ -450,6 +453,20 @@ GXAnalyze::GXAnalyze() {
 GXAnalyze::~GXAnalyze() {
 }
 
+int countDecimalPlaces(const std::string &str) {
+    size_t decimalPos = str.find('.');
+    if (decimalPos == std::string::npos) {
+        return 0;
+    }
+    return str.length() - decimalPos - 1;
+}
+
+std::string formatFloat(double number, int precision) {
+    std::ostringstream oss;
+    oss << std::fixed << std::setprecision(precision) << number;
+    return oss.str();
+}
+
 /*
  * 获取两个数值计算的结果
  */
@@ -747,8 +764,10 @@ GXATSNode GXAnalyze::doubleCalculate(GXATSNode left, GXATSNode right, string op)
         if ((left.token == "num" || left.token == "long") &&
             (right.token == "num" || right.token == "long")) {
             if (left.token == "num" || right.token == "num") {
-                float temp = stof(left.name) + stof(right.name);
-                result.name = to_string(temp);
+                int n = max(countDecimalPlaces(left.name), countDecimalPlaces(right.name));
+                double temp = stod(left.name) + stod(right.name);
+                string resNum = formatFloat(temp, n);
+                result.name = resNum;
                 result.token = "num";
             } else {
                 long temp = stol(left.name) + stol(right.name);
@@ -788,8 +807,10 @@ GXATSNode GXAnalyze::doubleCalculate(GXATSNode left, GXATSNode right, string op)
             (right.token == "num" || right.token == "long")) {
 
             if (left.token == "num" || right.token == "num") {
-                float temp = stof(left.name) - stof(right.name);
-                result.name = to_string(temp);
+                int n = max(countDecimalPlaces(left.name), countDecimalPlaces(right.name));
+                double temp = stod(left.name) - stod(right.name);
+                string resNum = formatFloat(temp, n);
+                result.name = resNum;
                 result.token = "num";
             } else {
                 long temp = stol(left.name) - stol(right.name);
@@ -822,8 +843,11 @@ GXATSNode GXAnalyze::doubleCalculate(GXATSNode left, GXATSNode right, string op)
         if ((left.token == "num" || left.token == "long") &&
             (right.token == "num" || right.token == "long")) {
             if (left.token == "num" || right.token == "num") {
-                float temp = stof(left.name) * stof(right.name);
-                result.name = to_string(temp);
+                //如果需要保留n位小数，那么输入时需要输入n位
+                int n = max(countDecimalPlaces(left.name), countDecimalPlaces(right.name));
+                double temp = stod(left.name) * stod(right.name);
+                string resNum = formatFloat(temp, n);
+                result.name = resNum;
                 result.token = "num";
             } else {
                 long temp = stol(left.name) * stol(right.name);
@@ -860,8 +884,10 @@ GXATSNode GXAnalyze::doubleCalculate(GXATSNode left, GXATSNode right, string op)
                 result.name = "expressionError: divide or mod by zero";
             } else {
                 if (left.token == "num" || right.token == "num") {
-                    float temp = stof(left.name) / stof(right.name);
-                    result.name = to_string(temp);
+                    int n = max(countDecimalPlaces(left.name), countDecimalPlaces(right.name));
+                    double temp = stod(left.name) / stod(right.name);
+                    string resNum = formatFloat(temp, n);
+                    result.name = resNum;
                     result.token = "num";
                 } else {
                     long temp = stol(left.name) / stol(right.name);
@@ -904,9 +930,17 @@ GXATSNode GXAnalyze::doubleCalculate(GXATSNode left, GXATSNode right, string op)
                 result.token = "error";
                 result.name = "expressionError: divide or mod by zero";
             } else {
-                long temp = stol(left.name) % stol(right.name);
-                result.name = to_string(temp);
-                result.token = "long";
+                if (left.token == "num" || right.token == "num") {
+                    int n = max(countDecimalPlaces(left.name), countDecimalPlaces(right.name));
+                    double temp = fmod(stod(left.name), stod(right.name));
+                    string resNum = formatFloat(temp, n);
+                    result.name = resNum;
+                    result.token = "num";
+                } else {
+                    long temp = stol(left.name) % stol(right.name);
+                    result.name = to_string(temp);
+                    result.token = "long";
+                }
             }
         } else if (left.token == "null" || right.token == "null") {
             result.name = "null";

--- a/GaiaXiOS/GaiaXiOS/Binding/Expression/GXAnalyzeCore/GXAnalyze.cpp
+++ b/GaiaXiOS/GaiaXiOS/Binding/Expression/GXAnalyzeCore/GXAnalyze.cpp
@@ -463,11 +463,6 @@ GXATSNode GXAnalyze::doubleCalculate(GXATSNode left, GXATSNode right, string op)
                       left.token + "'";
         result.token = "error";
         return result;
-    } else if (op != "?:" && (right.token == "map" || right.token == "array")) {
-        result.name = "expressionError: illegal operator '" + op + "',right operand has type of '" +
-                      right.token + "'";
-        result.token = "error";
-        return result;
     }
     //返回值都为bool
     if (op == ">") {
@@ -721,7 +716,8 @@ GXATSNode GXAnalyze::doubleCalculate(GXATSNode left, GXATSNode right, string op)
         } else {
             result.name = "false";
         }
-    } else if (op == "?") {
+    }
+    else if (op == "?") {
         if (left.name == "true" || ((left.name != "false" && left.token != "null"))) {
             result.name = right.name;
             result.token = right.token;
@@ -732,7 +728,8 @@ GXATSNode GXAnalyze::doubleCalculate(GXATSNode left, GXATSNode right, string op)
             result.token = "right";
             result.name = "right";
         }
-    } else if (op == "?:") {
+    }
+    else if (op == "?:") {
         if (left.name == "true" || (left.name != "false" && left.token != "null")) {
             result.name = left.name;
             result.token = left.token;
@@ -740,7 +737,8 @@ GXATSNode GXAnalyze::doubleCalculate(GXATSNode left, GXATSNode right, string op)
             result.name = right.name;
             result.token = right.token;
         }
-    } else if (op == ":") {
+    }
+    else if (op == ":") {
         if (left.token == "right" && left.name == "right") {
             result.token = right.token;
             result.name = right.name;
@@ -748,7 +746,8 @@ GXATSNode GXAnalyze::doubleCalculate(GXATSNode left, GXATSNode right, string op)
             result.token = left.token;
             result.name = left.name;
         }
-    } else if (op == "+") {
+    }
+    else if (op == "+") {
         if ((left.token == "num" || left.token == "long") &&
             (right.token == "num" || right.token == "long")) {
             if (left.token == "num" || right.token == "num") {
@@ -768,21 +767,9 @@ GXATSNode GXAnalyze::doubleCalculate(GXATSNode left, GXATSNode right, string op)
             result.token = "null";
         } else {
             if ((left.token == "num" || left.token == "long") && right.token == "string") {
-//                if (left.name.find('.') != -1) {
-//                    regex e("0+?$");
-//                    regex e2("[.]$");
-//                    left.name = regex_replace(left.name, e, "");
-//                    left.name = regex_replace(left.name, e2, "");
-//                }
                 result.name = left.name + right.name;
                 result.token = "string";
             } else if ((right.token == "num" || right.token == "long") && left.token == "string") {
-//                if (right.name.find('.') != -1) {
-//                    regex e("0+?$");
-//                    regex e2("[.]$");
-//                    right.name = regex_replace(right.name, e, ""); // 除了捕捉到的组以外，其他的东西均舍弃
-//                    right.name = regex_replace(right.name, e2, ""); // 除了捕捉到的组以外，其他的东西均舍弃
-//                }
                 result.name = left.name + right.name;
                 result.token = "string";
             } else {
@@ -800,7 +787,8 @@ GXATSNode GXAnalyze::doubleCalculate(GXATSNode left, GXATSNode right, string op)
                 }
             }
         }
-    } else if (op == "-") {
+    }
+    else if (op == "-") {
         if ((left.token == "num" || left.token == "long") &&
             (right.token == "num" || right.token == "long")) {
 
@@ -835,7 +823,8 @@ GXATSNode GXAnalyze::doubleCalculate(GXATSNode left, GXATSNode right, string op)
                         left.token;
             }
         }
-    } else if (op == "*") {
+    }
+    else if (op == "*") {
         if ((left.token == "num" || left.token == "long") &&
             (right.token == "num" || right.token == "long")) {
             if (left.token == "num" || right.token == "num") {
@@ -869,7 +858,8 @@ GXATSNode GXAnalyze::doubleCalculate(GXATSNode left, GXATSNode right, string op)
                         left.token;
             }
         }
-    } else if (op == "/") {
+    }
+    else if (op == "/") {
         if ((left.token == "num" || left.token == "long") &&
             (right.token == "num" || right.token == "long")) {
             if (stof(right.name) == 0) {
@@ -914,7 +904,8 @@ GXATSNode GXAnalyze::doubleCalculate(GXATSNode left, GXATSNode right, string op)
                         left.token;
             }
         }
-    } else if (op == "%") {
+    }
+    else if (op == "%") {
         if ((left.token == "num" || left.token == "long") &&
             (right.token == "num" || right.token == "long")) {
             if (stof(right.name) == 0) {
@@ -947,6 +938,10 @@ GXATSNode GXAnalyze::doubleCalculate(GXATSNode left, GXATSNode right, string op)
                         left.token;
             }
         }
+    }
+    else{
+        result.token = "error";
+        result.name = "expressionError: wrong expression";
     }
     return result;
 }
@@ -1068,6 +1063,9 @@ long GXAnalyze::getValue(string expression, void *source) {
                     } else if (gxv->tag == GX_TAG_NULL) {
                         tokenNum.name = "null";
                         tokenNum.token = "null";
+                    }else{
+                        tokenNum.name = "null";
+                        tokenNum.token = "null";
                     }
                     if (gxv->tag == GX_TAG_STRING && gxv->str != NULL) {
                         delete[] gxv->str;
@@ -1113,6 +1111,9 @@ long GXAnalyze::getValue(string expression, void *source) {
                     } else if (gxv->tag == GX_TAG_NULL) {
                         tokenNum.name = "null";
                         tokenNum.token = "null";
+                    }else{
+                        tokenNum.name = "null";
+                        tokenNum.token = "null";
                     }
                     if (gxv->tag == GX_TAG_STRING && gxv->str != NULL) {
                         delete[] gxv->str;
@@ -1152,12 +1153,6 @@ long GXAnalyze::getValue(string expression, void *source) {
                     pointer = new GXValue(GX_TAG_BOOL, 0);
                 }
             } else if (res.token == "num") {
-//                if (res.name.find('.') != -1) {
-//                    regex e("0+?$");
-//                    regex e2("[.]$");
-//                    res.name = regex_replace(res.name, e, "");
-//                    res.name = regex_replace(res.name, e2, "");
-//                }
                 pointer = new GXValue(GX_TAG_FLOAT, (float) atof(res.name.c_str()));
             } else if (res.token == "long") {
                 pointer = new GXValue(GX_TAG_LONG, (int64_t) atoll(res.name.c_str()));
@@ -1166,6 +1161,8 @@ long GXAnalyze::getValue(string expression, void *source) {
             } else if (res.token == "array") {
                 pointer = new GXValue(GX_TAG_ARRAY, (void *) atol(res.name.c_str()));
             } else if (res.token == "null") {
+                pointer = new GXValue(GX_TAG_NULL, 1);
+            }else{
                 pointer = new GXValue(GX_TAG_NULL, 1);
             }
             Res = (long) pointer;
@@ -1271,6 +1268,9 @@ GXAnalyze::calculateCache(string cacheString, vector<GXATSNode> array, void *p_a
                 } else if (node.token == "null") {
                     GXValue *par = new GXValue(GX_TAG_NULL, 1);
                     paramsTempArray.push_back((long) par);
+                }else{
+                    GXValue *par = new GXValue(GX_TAG_NULL, 1);
+                    paramsTempArray.push_back((long) par);
                 }
                 num1 = -1;
             } else if (cacheString[i] == 'g') {
@@ -1311,6 +1311,9 @@ GXAnalyze::calculateCache(string cacheString, vector<GXATSNode> array, void *p_a
                                 node.name.c_str()));
                         paramsTempArray.push_back((long) par);
                     } else if (node.token == "null") {
+                        GXValue *par = new GXValue(GX_TAG_NULL, 1);
+                        paramsTempArray.push_back((long) par);
+                    }else{
                         GXValue *par = new GXValue(GX_TAG_NULL, 1);
                         paramsTempArray.push_back((long) par);
                     }
@@ -1380,6 +1383,9 @@ GXAnalyze::calculateCache(string cacheString, vector<GXATSNode> array, void *p_a
                     } else if (fun->tag == GX_TAG_NULL) {
                         node.name = "null";
                         node.token = "null";
+                    }else{
+                        node.name = "null";
+                        node.token = "null";
                     }
                     array[numFunction] = node;
                     res = array[numFunction];
@@ -1417,12 +1423,6 @@ GXAnalyze::calculateCache(string cacheString, vector<GXATSNode> array, void *p_a
             pointer = new GXValue(GX_TAG_BOOL, 0);
         }
     } else if (res.token == "num") {
-//        if (res.name.find('.') != -1) {
-//            regex e("0+?$");
-//            regex e2("[.]$");
-//            res.name = regex_replace(res.name, e, "");
-//            res.name = regex_replace(res.name, e2, "");
-//        }
         pointer = new GXValue(GX_TAG_FLOAT, (float) atof(res.name.c_str()));
     } else if (res.token == "long") {
         pointer = new GXValue(GX_TAG_LONG, (int64_t) atoll(res.name.c_str()));
@@ -1431,6 +1431,8 @@ GXAnalyze::calculateCache(string cacheString, vector<GXATSNode> array, void *p_a
     } else if (res.token == "array") {
         pointer = new GXValue(GX_TAG_ARRAY, (void *) atol(res.name.c_str()));
     } else if (res.token == "null") {
+        pointer = new GXValue(GX_TAG_NULL, 1);
+    }else{
         pointer = new GXValue(GX_TAG_NULL, 1);
     }
 
@@ -1486,12 +1488,6 @@ long GXAnalyze::check(string s, vector<GXATSNode> array, void *p_analyze, void *
                     pointer = new GXValue(GX_TAG_BOOL, 0);
                 }
             } else if (valueStack[0].token == "num") {
-//                if (valueStack[0].name.find('.') != -1) {
-//                    regex e("0+?$");
-//                    regex e2("[.]$");
-//                    valueStack[0].name = regex_replace(valueStack[0].name, e, "");
-//                    valueStack[0].name = regex_replace(valueStack[0].name, e2, "");
-//                }
                 pointer = new GXValue(GX_TAG_FLOAT, (float) atof(valueStack[0].name.c_str()));
             } else if (valueStack[0].token == "long") {
                 pointer = new GXValue(GX_TAG_LONG, (int64_t) atoll(valueStack[0].name.c_str()));
@@ -1500,6 +1496,8 @@ long GXAnalyze::check(string s, vector<GXATSNode> array, void *p_analyze, void *
             } else if (valueStack[0].token == "array") {
                 pointer = new GXValue(GX_TAG_ARRAY, (void *) atol(valueStack[0].name.c_str()));
             } else if (valueStack[0].token == "null") {
+                pointer = new GXValue(GX_TAG_NULL, 1);
+            }else{
                 pointer = new GXValue(GX_TAG_NULL, 1);
             }
             delete[] statusStack;
@@ -1578,6 +1576,9 @@ long GXAnalyze::check(string s, vector<GXATSNode> array, void *p_analyze, void *
                         } else if (gxv->tag == GX_TAG_NULL) {
                             t1.name = "null";
                             t1.token = "null";
+                        }else{
+                            t1.name = "null";
+                            t1.token = "null";
                         }
                         valueStack[valueSize] = t1;
                         ++valueSize;
@@ -1627,6 +1628,9 @@ long GXAnalyze::check(string s, vector<GXATSNode> array, void *p_analyze, void *
                             t1.name = to_string((long) (gxv->ptr));
                             t1.token = "map";
                         } else if (gxv->tag == GX_TAG_NULL) {
+                            t1.name = "null";
+                            t1.token = "null";
+                        }else{
                             t1.name = "null";
                             t1.token = "null";
                         }
@@ -1784,6 +1788,9 @@ long GXAnalyze::check(string s, vector<GXATSNode> array, void *p_analyze, void *
                                         } else if (fun->tag == GX_TAG_NULL) {
                                             tempR.name = "null";
                                             tempR.token = "null";
+                                        }else{
+                                            tempR.name = "null";
+                                            tempR.token = "null";
                                         }
                                         --valueSize;
                                         isFunction = false;
@@ -1831,6 +1838,9 @@ long GXAnalyze::check(string s, vector<GXATSNode> array, void *p_analyze, void *
                                                     valueStack[i].name.c_str()));
                                             paramsTempArray.push_back((long) par);
                                         } else if (valueStack[i].token == "null") {
+                                            GXValue *par = new GXValue(GX_TAG_NULL, 1);
+                                            paramsTempArray.push_back((long) par);
+                                        }else{
                                             GXValue *par = new GXValue(GX_TAG_NULL, 1);
                                             paramsTempArray.push_back((long) par);
                                         }

--- a/GaiaXiOS/GaiaXiOS/Binding/Expression/GXAnalyzeCore/GXAnalyze.cpp
+++ b/GaiaXiOS/GaiaXiOS/Binding/Expression/GXAnalyzeCore/GXAnalyze.cpp
@@ -716,8 +716,7 @@ GXATSNode GXAnalyze::doubleCalculate(GXATSNode left, GXATSNode right, string op)
         } else {
             result.name = "false";
         }
-    }
-    else if (op == "?") {
+    } else if (op == "?") {
         if (left.name == "true" || ((left.name != "false" && left.token != "null"))) {
             result.name = right.name;
             result.token = right.token;
@@ -728,8 +727,7 @@ GXATSNode GXAnalyze::doubleCalculate(GXATSNode left, GXATSNode right, string op)
             result.token = "right";
             result.name = "right";
         }
-    }
-    else if (op == "?:") {
+    } else if (op == "?:") {
         if (left.name == "true" || (left.name != "false" && left.token != "null")) {
             result.name = left.name;
             result.token = left.token;
@@ -737,8 +735,7 @@ GXATSNode GXAnalyze::doubleCalculate(GXATSNode left, GXATSNode right, string op)
             result.name = right.name;
             result.token = right.token;
         }
-    }
-    else if (op == ":") {
+    } else if (op == ":") {
         if (left.token == "right" && left.name == "right") {
             result.token = right.token;
             result.name = right.name;
@@ -746,15 +743,14 @@ GXATSNode GXAnalyze::doubleCalculate(GXATSNode left, GXATSNode right, string op)
             result.token = left.token;
             result.name = left.name;
         }
-    }
-    else if (op == "+") {
+    } else if (op == "+") {
         if ((left.token == "num" || left.token == "long") &&
             (right.token == "num" || right.token == "long")) {
             if (left.token == "num" || right.token == "num") {
                 float temp = stof(left.name) + stof(right.name);
                 result.name = to_string(temp);
                 result.token = "num";
-            }else{
+            } else {
                 long temp = stol(left.name) + stol(right.name);
                 result.name = to_string(temp);
                 result.token = "long";
@@ -787,8 +783,7 @@ GXATSNode GXAnalyze::doubleCalculate(GXATSNode left, GXATSNode right, string op)
                 }
             }
         }
-    }
-    else if (op == "-") {
+    } else if (op == "-") {
         if ((left.token == "num" || left.token == "long") &&
             (right.token == "num" || right.token == "long")) {
 
@@ -796,7 +791,7 @@ GXATSNode GXAnalyze::doubleCalculate(GXATSNode left, GXATSNode right, string op)
                 float temp = stof(left.name) - stof(right.name);
                 result.name = to_string(temp);
                 result.token = "num";
-            }else{
+            } else {
                 long temp = stol(left.name) - stol(right.name);
                 result.name = to_string(temp);
                 result.token = "long";
@@ -823,15 +818,14 @@ GXATSNode GXAnalyze::doubleCalculate(GXATSNode left, GXATSNode right, string op)
                         left.token;
             }
         }
-    }
-    else if (op == "*") {
+    } else if (op == "*") {
         if ((left.token == "num" || left.token == "long") &&
             (right.token == "num" || right.token == "long")) {
             if (left.token == "num" || right.token == "num") {
                 float temp = stof(left.name) * stof(right.name);
                 result.name = to_string(temp);
                 result.token = "num";
-            }else{
+            } else {
                 long temp = stol(left.name) * stol(right.name);
                 result.name = to_string(temp);
                 result.token = "long";
@@ -858,8 +852,7 @@ GXATSNode GXAnalyze::doubleCalculate(GXATSNode left, GXATSNode right, string op)
                         left.token;
             }
         }
-    }
-    else if (op == "/") {
+    } else if (op == "/") {
         if ((left.token == "num" || left.token == "long") &&
             (right.token == "num" || right.token == "long")) {
             if (stof(right.name) == 0) {
@@ -870,13 +863,13 @@ GXATSNode GXAnalyze::doubleCalculate(GXATSNode left, GXATSNode right, string op)
                     float temp = stof(left.name) / stof(right.name);
                     result.name = to_string(temp);
                     result.token = "num";
-                }else{
+                } else {
                     long temp = stol(left.name) / stol(right.name);
                     long double tempF = stold(left.name) / stold(right.name);
-                    if(temp != tempF && (left.token == "num" || right.token == "num")){
+                    if (temp != tempF && (left.token == "num" || right.token == "num")) {
                         result.name = to_string(tempF);
                         result.token = "num";
-                    }else{
+                    } else {
                         result.name = to_string(temp);
                         result.token = "long";
                     }
@@ -904,8 +897,7 @@ GXATSNode GXAnalyze::doubleCalculate(GXATSNode left, GXATSNode right, string op)
                         left.token;
             }
         }
-    }
-    else if (op == "%") {
+    } else if (op == "%") {
         if ((left.token == "num" || left.token == "long") &&
             (right.token == "num" || right.token == "long")) {
             if (stof(right.name) == 0) {
@@ -938,8 +930,7 @@ GXATSNode GXAnalyze::doubleCalculate(GXATSNode left, GXATSNode right, string op)
                         left.token;
             }
         }
-    }
-    else{
+    } else {
         result.token = "error";
         result.name = "expressionError: wrong expression";
     }
@@ -1063,7 +1054,7 @@ long GXAnalyze::getValue(string expression, void *source) {
                     } else if (gxv->tag == GX_TAG_NULL) {
                         tokenNum.name = "null";
                         tokenNum.token = "null";
-                    }else{
+                    } else {
                         tokenNum.name = "null";
                         tokenNum.token = "null";
                     }
@@ -1111,7 +1102,7 @@ long GXAnalyze::getValue(string expression, void *source) {
                     } else if (gxv->tag == GX_TAG_NULL) {
                         tokenNum.name = "null";
                         tokenNum.token = "null";
-                    }else{
+                    } else {
                         tokenNum.name = "null";
                         tokenNum.token = "null";
                     }
@@ -1162,7 +1153,7 @@ long GXAnalyze::getValue(string expression, void *source) {
                 pointer = new GXValue(GX_TAG_ARRAY, (void *) atol(res.name.c_str()));
             } else if (res.token == "null") {
                 pointer = new GXValue(GX_TAG_NULL, 1);
-            }else{
+            } else {
                 pointer = new GXValue(GX_TAG_NULL, 1);
             }
             Res = (long) pointer;
@@ -1268,7 +1259,7 @@ GXAnalyze::calculateCache(string cacheString, vector<GXATSNode> array, void *p_a
                 } else if (node.token == "null") {
                     GXValue *par = new GXValue(GX_TAG_NULL, 1);
                     paramsTempArray.push_back((long) par);
-                }else{
+                } else {
                     GXValue *par = new GXValue(GX_TAG_NULL, 1);
                     paramsTempArray.push_back((long) par);
                 }
@@ -1313,7 +1304,7 @@ GXAnalyze::calculateCache(string cacheString, vector<GXATSNode> array, void *p_a
                     } else if (node.token == "null") {
                         GXValue *par = new GXValue(GX_TAG_NULL, 1);
                         paramsTempArray.push_back((long) par);
-                    }else{
+                    } else {
                         GXValue *par = new GXValue(GX_TAG_NULL, 1);
                         paramsTempArray.push_back((long) par);
                     }
@@ -1383,7 +1374,7 @@ GXAnalyze::calculateCache(string cacheString, vector<GXATSNode> array, void *p_a
                     } else if (fun->tag == GX_TAG_NULL) {
                         node.name = "null";
                         node.token = "null";
-                    }else{
+                    } else {
                         node.name = "null";
                         node.token = "null";
                     }
@@ -1432,7 +1423,7 @@ GXAnalyze::calculateCache(string cacheString, vector<GXATSNode> array, void *p_a
         pointer = new GXValue(GX_TAG_ARRAY, (void *) atol(res.name.c_str()));
     } else if (res.token == "null") {
         pointer = new GXValue(GX_TAG_NULL, 1);
-    }else{
+    } else {
         pointer = new GXValue(GX_TAG_NULL, 1);
     }
 
@@ -1497,7 +1488,7 @@ long GXAnalyze::check(string s, vector<GXATSNode> array, void *p_analyze, void *
                 pointer = new GXValue(GX_TAG_ARRAY, (void *) atol(valueStack[0].name.c_str()));
             } else if (valueStack[0].token == "null") {
                 pointer = new GXValue(GX_TAG_NULL, 1);
-            }else{
+            } else {
                 pointer = new GXValue(GX_TAG_NULL, 1);
             }
             delete[] statusStack;
@@ -1576,7 +1567,7 @@ long GXAnalyze::check(string s, vector<GXATSNode> array, void *p_analyze, void *
                         } else if (gxv->tag == GX_TAG_NULL) {
                             t1.name = "null";
                             t1.token = "null";
-                        }else{
+                        } else {
                             t1.name = "null";
                             t1.token = "null";
                         }
@@ -1630,7 +1621,7 @@ long GXAnalyze::check(string s, vector<GXATSNode> array, void *p_analyze, void *
                         } else if (gxv->tag == GX_TAG_NULL) {
                             t1.name = "null";
                             t1.token = "null";
-                        }else{
+                        } else {
                             t1.name = "null";
                             t1.token = "null";
                         }
@@ -1788,7 +1779,7 @@ long GXAnalyze::check(string s, vector<GXATSNode> array, void *p_analyze, void *
                                         } else if (fun->tag == GX_TAG_NULL) {
                                             tempR.name = "null";
                                             tempR.token = "null";
-                                        }else{
+                                        } else {
                                             tempR.name = "null";
                                             tempR.token = "null";
                                         }
@@ -1840,7 +1831,7 @@ long GXAnalyze::check(string s, vector<GXATSNode> array, void *p_analyze, void *
                                         } else if (valueStack[i].token == "null") {
                                             GXValue *par = new GXValue(GX_TAG_NULL, 1);
                                             paramsTempArray.push_back((long) par);
-                                        }else{
+                                        } else {
                                             GXValue *par = new GXValue(GX_TAG_NULL, 1);
                                             paramsTempArray.push_back((long) par);
                                         }

--- a/GaiaXiOS/GaiaXiOS/Binding/Expression/GXAnalyzeCore/GXAnalyze.cpp
+++ b/GaiaXiOS/GaiaXiOS/Binding/Expression/GXAnalyzeCore/GXAnalyze.cpp
@@ -1,5 +1,8 @@
 #include "GXAnalyze.h"
 #include <mutex>          // std::mutex
+#include<cmath>   //c头文件
+#include <sstream>
+#include <iomanip>
 
 using namespace std;
 
@@ -450,6 +453,20 @@ GXAnalyze::GXAnalyze() {
 GXAnalyze::~GXAnalyze() {
 }
 
+int countDecimalPlaces(const std::string &str) {
+    size_t decimalPos = str.find('.');
+    if (decimalPos == std::string::npos) {
+        return 0;
+    }
+    return str.length() - decimalPos - 1;
+}
+
+std::string formatFloat(double number, int precision) {
+    std::ostringstream oss;
+    oss << std::fixed << std::setprecision(precision) << number;
+    return oss.str();
+}
+
 /*
  * 获取两个数值计算的结果
  */
@@ -747,8 +764,10 @@ GXATSNode GXAnalyze::doubleCalculate(GXATSNode left, GXATSNode right, string op)
         if ((left.token == "num" || left.token == "long") &&
             (right.token == "num" || right.token == "long")) {
             if (left.token == "num" || right.token == "num") {
-                float temp = stof(left.name) + stof(right.name);
-                result.name = to_string(temp);
+                int n = max(countDecimalPlaces(left.name), countDecimalPlaces(right.name));
+                double temp = stod(left.name) + stod(right.name);
+                string resNum = formatFloat(temp, n);
+                result.name = resNum;
                 result.token = "num";
             } else {
                 long temp = stol(left.name) + stol(right.name);
@@ -788,8 +807,10 @@ GXATSNode GXAnalyze::doubleCalculate(GXATSNode left, GXATSNode right, string op)
             (right.token == "num" || right.token == "long")) {
 
             if (left.token == "num" || right.token == "num") {
-                float temp = stof(left.name) - stof(right.name);
-                result.name = to_string(temp);
+                int n = max(countDecimalPlaces(left.name), countDecimalPlaces(right.name));
+                double temp = stod(left.name) - stod(right.name);
+                string resNum = formatFloat(temp, n);
+                result.name = resNum;
                 result.token = "num";
             } else {
                 long temp = stol(left.name) - stol(right.name);
@@ -822,8 +843,11 @@ GXATSNode GXAnalyze::doubleCalculate(GXATSNode left, GXATSNode right, string op)
         if ((left.token == "num" || left.token == "long") &&
             (right.token == "num" || right.token == "long")) {
             if (left.token == "num" || right.token == "num") {
-                float temp = stof(left.name) * stof(right.name);
-                result.name = to_string(temp);
+                //如果需要保留n位小数，那么输入时需要输入n位
+                int n = max(countDecimalPlaces(left.name), countDecimalPlaces(right.name));
+                double temp = stod(left.name) * stod(right.name);
+                string resNum = formatFloat(temp, n);
+                result.name = resNum;
                 result.token = "num";
             } else {
                 long temp = stol(left.name) * stol(right.name);
@@ -860,8 +884,10 @@ GXATSNode GXAnalyze::doubleCalculate(GXATSNode left, GXATSNode right, string op)
                 result.name = "expressionError: divide or mod by zero";
             } else {
                 if (left.token == "num" || right.token == "num") {
-                    float temp = stof(left.name) / stof(right.name);
-                    result.name = to_string(temp);
+                    int n = max(countDecimalPlaces(left.name), countDecimalPlaces(right.name));
+                    double temp = stod(left.name) / stod(right.name);
+                    string resNum = formatFloat(temp, n);
+                    result.name = resNum;
                     result.token = "num";
                 } else {
                     long temp = stol(left.name) / stol(right.name);
@@ -904,9 +930,17 @@ GXATSNode GXAnalyze::doubleCalculate(GXATSNode left, GXATSNode right, string op)
                 result.token = "error";
                 result.name = "expressionError: divide or mod by zero";
             } else {
-                long temp = stol(left.name) % stol(right.name);
-                result.name = to_string(temp);
-                result.token = "long";
+                if (left.token == "num" || right.token == "num") {
+                    int n = max(countDecimalPlaces(left.name), countDecimalPlaces(right.name));
+                    double temp = fmod(stod(left.name), stod(right.name));
+                    string resNum = formatFloat(temp, n);
+                    result.name = resNum;
+                    result.token = "num";
+                } else {
+                    long temp = stol(left.name) % stol(right.name);
+                    result.name = to_string(temp);
+                    result.token = "long";
+                }
             }
         } else if (left.token == "null" || right.token == "null") {
             result.name = "null";


### PR DESCRIPTION
#424 
- 修复浮点数精度问题：
  - 使用浮点数时，需要保留小数位数变为可控：
    - 如需保留n位小数，则在计算时可以给运算添加n位小数点
    - examp：
      - 1.225*2 = 2.450
      - 1 + 3 + 1.00000 = 5.00000
      - 1 + 10.5 = 11.5 